### PR TITLE
Add service metadata JSON fixture

### DIFF
--- a/spec/fixtures/service.json
+++ b/spec/fixtures/service.json
@@ -1,0 +1,32 @@
+{
+  "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
+  "service_name": "Service Name",
+  "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
+  "created_at": "2020-10-09T11:51:46",
+  "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+  "configuration": {
+    "_id": "service",
+    "_type": "config.service"
+  },
+  "pages": [
+    {
+      "_id": "page.start",
+      "_type": "page.start",
+      "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
+      "heading": "Complain about a court or tribunal",
+      "lede": "Your complaint will not affect your case.",
+      "steps": [
+        "page-2",
+        "page.do-you-have-a-case-number"
+      ],
+      "url": "/"
+    },
+    {
+      "_id": "page-2",
+      "_type": "page",
+      "body": "This is page two",
+      "url": "/page-2"
+    }
+  ],
+  "locale": "en"
+}


### PR DESCRIPTION
This is a temporary file for use by the metadata presenter gem if no raw metadata is passed into it.

This is not the actual service JSON location we will be using in the future but will do for now.

https://trello.com/c/QOHT8XOs/1076-create-barebones-fb-runner

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>