### PR TITLE
Base schema validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 482c60c155a008f0d336665ee94307ec592c7a80
+  revision: 723f0dee2a5855b914aea3ba6e39be794343d81a
   branch: main
   specs:
     metadata_presenter (0.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,16 @@
 class ApplicationController < ActionController::Base
-	def service_metadata	
-    Rails.configuration.service_metadata	
+  def service
+    Rails.configuration.service
+  end
+  helper_method :service
+
+  def service_metadata
+    Rails.configuration.service_metadata
+  end
+
+  def save_user_data
+  end
+
+  def load_user_data
   end
 end

--- a/app/views/header/show.html.erb
+++ b/app/views/header/show.html.erb
@@ -24,10 +24,10 @@
         </span>
       </a>
     </div>
-    <% if @service.service_name.present? %>
+    <% if service.service_name.present? %>
       <div class="govuk-header__content">
         <a href="/" class="govuk-header__link govuk-header__link--service-name">
-          <%= @service.service_name %>
+          <%= service.service_name %>
         </a>
     <% end %>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>FbRunner</title>
+    <title><%= service.service_name %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/config/initializers/service_metadata.rb
+++ b/config/initializers/service_metadata.rb
@@ -5,6 +5,12 @@ if File.exist?(Rails.root.join('spec', 'fixtures', 'service.json'))
   Rails.configuration.service_metadata = JSON.parse(
     File.read(Rails.root.join('spec', 'fixtures', 'service.json'))
   )
+
+  MetadataPresenter::Schema.new(Rails.configuration.service_metadata).validate
+
+  Rails.configuration.service = MetadataPresenter::Service.new(
+    Rails.configuration.service_metadata
+  )
 else
   raise ServiceMetadataNotFoundError.new('No service metadata found')
 end

--- a/spec/fixtures/service.json
+++ b/spec/fixtures/service.json
@@ -1,4 +1,5 @@
 {
+  "_type": "service.base",
   "service_id": "634aa3d5-a3b3-4d0f-9078-bb754542a1d3",
   "service_name": "Service Name",
   "version_id": "ac4b45c5-071e-4d07-b5a2-9f0196a5b267",
@@ -16,16 +17,41 @@
       "heading": "Complain about a court or tribunal",
       "lede": "Your complaint will not affect your case.",
       "steps": [
-        "page-2",
-        "page.do-you-have-a-case-number"
+        "page.text-first",
+        "page.text-second"
       ],
       "url": "/"
     },
     {
-      "_id": "page-2",
-      "_type": "page",
-      "body": "This is page two",
-      "url": "/page-2"
+      "_id": "page.text-first",
+      "_type": "page.singlequestion",
+      "components": [
+        {
+          "_id": "page.text-first--text.auto_name__1",
+          "_type": "text",
+          "hint": "Text - First - hint text",
+          "label": "Text - First",
+          "name": "auto_name__1"
+        }
+      ],
+      "section_heading": "Text - First - section heading",
+      "url": "/text-first"
+    },
+    {
+      "_id": "page.text-second",
+      "_type": "page.singlequestion",
+      "section_heading": "Text - Second - section heading",
+      "components": [
+        {
+          "_id": "page.text-second--text.auto_name__2",
+          "_type": "text",
+          "hint": "Text - Second - hint text",
+          "label": "Text - Second",
+          "label_summary": "Text - Second - summary version",
+          "name": "auto_name__2"
+        }
+      ],
+      "url": "/text-second"
     }
   ],
   "locale": "en"


### PR DESCRIPTION
This will validate the base schema only on startup of the app

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>