### PR TITLE
Datastore/integration part 2

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,4 @@
 class ApplicationController < ActionController::Base
-  before_action :log_info, if: -> { Rails.env.development? }
-
-  def log_info
-    Rails.logger.info("User identifiter: #{session[:session_id]}. Token: #{session[:user_token]}")
-  end
-
   EXCEPTIONS = [
     UserDatastoreAdapter::DatastoreTimeoutError,
     UserDatastoreAdapter::DatastoreClientError

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :log_info, if: -> { Rails.env.development? }
+
+  def log_info
+    Rails.logger.info("User identifiter: #{session[:session_id]}. Token: #{session[:user_token]}")
+  end
+
   EXCEPTIONS = [
     UserDatastoreAdapter::DatastoreTimeoutError,
     UserDatastoreAdapter::DatastoreClientError

--- a/app/models/service_access_token.rb
+++ b/app/models/service_access_token.rb
@@ -1,10 +1,10 @@
 class ServiceAccessToken
-  attr_reader :encoded_private_key, :issuer, :namespace, :subject
+  ISSUER = 'fb-runner'
+  attr_reader :encoded_private_key, :issuer, :subject
 
   def initialize(subject: nil, encoded_private_key: ENV['ENCODED_PRIVATE_KEY'])
     @encoded_private_key = encoded_private_key
-    @issuer = 'fb-runner'
-    @namespace = 'formbuilder-services-live-production'
+    @issuer = ISSUER
     @subject = subject
   end
 
@@ -25,10 +25,16 @@ class ServiceAccessToken
   def token
     payload = {
       iss: issuer,
-      namespace: namespace,
-      iat: Time.current.to_i,
+      iat: Time.current.to_i
     }
     payload[:sub] = subject if subject.present?
+    payload[:namespace] = namespace if namespace.present?
     payload
+  end
+
+  def namespace
+    if ENV['PLATFORM_ENV'].present? && ENV['DEPLOYMENT_ENV'].present?
+      "formbuilder-services-#{ENV['PLATFORM_ENV']}-#{ENV['DEPLOYMENT_ENV']}"
+    end
   end
 end

--- a/app/models/service_access_token.rb
+++ b/app/models/service_access_token.rb
@@ -1,11 +1,13 @@
 class ServiceAccessToken
   ISSUER = 'fb-runner'
-  attr_reader :encoded_private_key, :issuer, :subject
+  attr_reader :encoded_private_key, :issuer, :subject, :platform_env, :deployment_env
 
-  def initialize(subject: nil, encoded_private_key: ENV['ENCODED_PRIVATE_KEY'])
+  def initialize(subject: nil, encoded_private_key: ENV['ENCODED_PRIVATE_KEY'], platform_env: ENV['PLATFORM_ENV'], deployment_env: ENV['DEPLOYMENT_ENV'])
     @encoded_private_key = encoded_private_key
     @issuer = ISSUER
     @subject = subject
+    @platform_env = platform_env
+    @deployment_env = deployment_env
   end
 
   def generate
@@ -33,8 +35,8 @@ class ServiceAccessToken
   end
 
   def namespace
-    if ENV['PLATFORM_ENV'].present? && ENV['DEPLOYMENT_ENV'].present?
-      "formbuilder-services-#{ENV['PLATFORM_ENV']}-#{ENV['DEPLOYMENT_ENV']}"
-    end
+    return if platform_env.blank? || deployment_env.blank?
+
+    "formbuilder-services-#{platform_env}-#{deployment_env}"
   end
 end

--- a/app/models/service_access_token.rb
+++ b/app/models/service_access_token.rb
@@ -9,7 +9,7 @@ class ServiceAccessToken
   end
 
   def generate
-    return if encoded_private_key.blank?
+    return '' if encoded_private_key.blank?
 
     private_key = OpenSSL::PKey::RSA.new(Base64.strict_decode64(encoded_private_key.chomp))
 

--- a/app/models/user_datastore_adapter.rb
+++ b/app/models/user_datastore_adapter.rb
@@ -1,6 +1,7 @@
 class UserDatastoreAdapter
   class DatastoreTimeoutError < StandardError; end
   class DatastoreClientError < StandardError; end
+  class DatastoreResourceNotFound < StandardError; end
   TIMEOUT = 15
   SUBSCRIPTION = 'datastore.request'
 
@@ -27,6 +28,8 @@ class UserDatastoreAdapter
     response = request(:get, {}).body['payload'] || {}
 
     JSON.parse(data_encryption.decrypt(response)) || {}
+  rescue DatastoreResourceNotFound
+    {}
   end
 
   private
@@ -68,6 +71,8 @@ class UserDatastoreAdapter
     connection.send(verb, url, body, headers)
   rescue Faraday::ConnectionFailed, Faraday::TimeoutError => exception
     raise DatastoreTimeoutError.new(exception.message)
+  rescue Faraday::ResourceNotFound => exception
+    raise DatastoreResourceNotFound.new(exception.message)
   rescue StandardError => exception
     raise DatastoreClientError.new(exception.message)
   end

--- a/app/models/user_datastore_adapter.rb
+++ b/app/models/user_datastore_adapter.rb
@@ -54,7 +54,8 @@ class UserDatastoreAdapter
     {
       'Accept' => 'application/json',
       'Content-Type' => 'application/json',
-      'User-Agent' => 'Runner'
+      'User-Agent' => 'Runner',
+      'x-access-token-v2' => service_access_token
     }
   end
 
@@ -67,7 +68,7 @@ class UserDatastoreAdapter
       conn.options[:open_timeout] = TIMEOUT
       conn.options[:timeout] = TIMEOUT
 
-      conn.authorization :Bearer, ServiceAccessToken.new(subject: subject).generate
+      conn.authorization :Bearer, service_access_token
     end
   end
 
@@ -79,5 +80,9 @@ class UserDatastoreAdapter
     raise DatastoreResourceNotFound.new(exception.message)
   rescue StandardError => exception
     raise DatastoreClientError.new(exception.message)
+  end
+
+  def service_access_token
+    @service_access_token ||= ServiceAccessToken.new(subject: subject).generate
   end
 end

--- a/app/models/user_datastore_adapter.rb
+++ b/app/models/user_datastore_adapter.rb
@@ -35,8 +35,7 @@ class UserDatastoreAdapter
   private
 
   def data_encryption
-    # TODO: change to session token?
-    @data_encryption = DataEncryption.new(key: subject)
+    @data_encryption = DataEncryption.new(key: user_token)
   end
 
   def url
@@ -45,6 +44,10 @@ class UserDatastoreAdapter
 
   def subject
     session[:session_id]
+  end
+
+  def user_token
+    session[:user_token] ||= SecureRandom.uuid.gsub('-', '')
   end
 
   def headers

--- a/app/models/user_datastore_adapter.rb
+++ b/app/models/user_datastore_adapter.rb
@@ -52,7 +52,6 @@ class UserDatastoreAdapter
 
   def headers
     {
-      'x-access-token-v2' => ServiceAccessToken.new(subject: subject).generate,
       'Accept' => 'application/json',
       'Content-Type' => 'application/json',
       'User-Agent' => 'Runner'
@@ -67,6 +66,8 @@ class UserDatastoreAdapter
       conn.use :instrumentation, name: SUBSCRIPTION
       conn.options[:open_timeout] = TIMEOUT
       conn.options[:timeout] = TIMEOUT
+
+      conn.authorization :Bearer, ServiceAccessToken.new(subject: subject).generate
     end
   end
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :answers]

--- a/spec/models/service_access_token_spec.rb
+++ b/spec/models/service_access_token_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe ServiceAccessToken do
           {
             'iat' => 1607367600,
             'iss' => 'fb-runner',
-            'namespace' => 'formbuilder-services-live-production',
             'sub' => 'user-id-123'
           },
           {
@@ -57,8 +56,26 @@ RSpec.describe ServiceAccessToken do
         ).to eq([
           {
             'iat' => 1607367600,
+            'iss' => 'fb-runner'
+          },
+          {
+            'alg' => 'RS256'
+          }
+        ])
+      end
+    end
+
+    context 'when there is a namespace' do
+      let(:subject) { nil }
+
+      it 'generate jwt access token without a sub' do
+        expect(
+          JWT.decode(service_token.generate, public_key, true, { algorithm: 'RS256' })
+        ).to eq([
+          {
+            'iat' => 1607367600,
             'iss' => 'fb-runner',
-            'namespace' => 'formbuilder-services-live-production'
+            'namespace' => 'formbuilder-services-test-dev'
           },
           {
             'alg' => 'RS256'

--- a/spec/models/service_access_token_spec.rb
+++ b/spec/models/service_access_token_spec.rb
@@ -5,14 +5,11 @@ RSpec.describe ServiceAccessToken do
   end
   let(:public_key) { private_key.public_key }
 
-  before do
-    allow(ENV).to receive(:[])
-      .with('ENCODED_PRIVATE_KEY').and_return(encoded_private_key)
-  end
-
   describe '#generate' do
+    let(:platform_env) { nil }
+    let(:deployment_env) { nil }
     let(:service_token) do
-      ServiceAccessToken.new(subject: subject)
+      ServiceAccessToken.new(subject: subject, encoded_private_key: encoded_private_key, platform_env: platform_env, deployment_env: deployment_env)
     end
 
     before do
@@ -67,6 +64,8 @@ RSpec.describe ServiceAccessToken do
 
     context 'when there is a namespace' do
       let(:subject) { nil }
+      let(:platform_env) { 'test' }
+      let(:deployment_env) { 'dev' }
 
       it 'generate jwt access token without a sub' do
         expect(

--- a/spec/models/service_access_token_spec.rb
+++ b/spec/models/service_access_token_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ServiceAccessToken do
       let(:subject) { nil }
 
       it 'returns nil' do
-        expect(service_token.generate).to be(nil)
+        expect(service_token.generate).to eq('')
       end
     end
 

--- a/spec/models/user_datastore_adapter_spec.rb
+++ b/spec/models/user_datastore_adapter_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe UserDatastoreAdapter do
   let(:expected_headers) do
     {
       'Authorization' => 'Bearer some-token',
+      'x-access-token-v2' => 'some-token',
       'Accept' => 'application/json',
       'Content-Type' => 'application/json',
       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',

--- a/spec/models/user_datastore_adapter_spec.rb
+++ b/spec/models/user_datastore_adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UserDatastoreAdapter do
     'http://user-datastore.com'
   end
   let(:expected_url) do
-    URI.join(root_url, '/service/court-service/user/474c39bf61287d4ec0aa1276f089d2e3')
+    URI.join(root_url, '/service/court-service/user/8b62ea25319b4ad8a889174dca57e061')
   end
   let(:expected_headers) do
     {
@@ -31,8 +31,8 @@ RSpec.describe UserDatastoreAdapter do
   end
   let(:session) do
     {
-      session_id: '474c39bf61287d4ec0aa1276f089d2e3',
-      token: ''
+      session_id: '8b62ea25319b4ad8a889174dca57e061',
+      user_token: '474c39bf61287d4ec0aa1276f089d2e3'
     }
   end
   let(:empty_payload) do

--- a/spec/models/user_datastore_adapter_spec.rb
+++ b/spec/models/user_datastore_adapter_spec.rb
@@ -77,11 +77,11 @@ RSpec.describe UserDatastoreAdapter do
         before do
           stub_request(:get, expected_url)
             .with(body: {}, headers: expected_headers)
-            .to_return(status: 200, body: empty_payload, headers: {})
+            .to_return(status: 404, body: empty_payload, headers: {})
 
           stub_request(:post, expected_url)
             .with(body: expected_body, headers: expected_headers)
-            .to_return(status: 200, body: expected_body, headers: {})
+            .to_return(status: 201, body: expected_body, headers: {})
         end
 
         it 'sends request to datastore' do

--- a/spec/models/user_datastore_adapter_spec.rb
+++ b/spec/models/user_datastore_adapter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UserDatastoreAdapter do
   end
   let(:expected_headers) do
     {
-      'x-access-token-v2' => 'some-token',
+      'Authorization' => 'Bearer some-token',
       'Accept' => 'application/json',
       'Content-Type' => 'application/json',
       'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',


### PR DESCRIPTION
[Trello Card](https://trello.com/c/OkFnAAlY/1095-save-text-field-component-user-data-to-datastore-continue)

## Context

So we started to add the datastore integration on this PR #28 

This is the part 2 and this PR contains:

- Make load data ignore 404 (this raises an error on the first try to save the answer because there is no data)
- Generate a user token in the session (on this PR we are using the session id)
- Use the user token in the session above to encrypt and decrypt the payload
- Change the namespace on the Service access token class
- Use the ` Bearer` token in the authorisation header and also the x-access-token-v2 (see commits for more info)

## Next steps

- We need to start the runner/datastore/service-token-cache and see if there is anything left to be done.
- Double check the old runner to see if there are more details that we miss.

## Diagrams

Same diagrams from the old PR that could help.

![Save session (1)](https://user-images.githubusercontent.com/27509/101614502-c9c28b80-39eb-11eb-8b98-0cd9c8cfd035.jpg)
