### PR TITLE
Add datastore response status to log

### DIFF
--- a/config/initializers/datastore_instrumentation.rb
+++ b/config/initializers/datastore_instrumentation.rb
@@ -2,5 +2,6 @@ ActiveSupport::Notifications.subscribe(UserDatastoreAdapter::SUBSCRIPTION) do |n
   url = env[:url]
   http_method = env[:method].to_s.upcase
   duration = ends - starts
-  Rails.logger.info('Datastore request: [%s] %s (%.3f s)' % [url.host, http_method, duration])
+  response_status = env[:status]
+  Rails.logger.info('Datastore request: [%s] %s (%.3f s). Response status: %s' % [url.host, http_method, duration, response_status])
 end


### PR DESCRIPTION
We are logging the datastore request (only the verb and the request
duration) and we decided to add the response status so it can
be easier to debug problems in development and also in production

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>