### PR TITLE
Add validation specs in feature specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 3121dd32c4bddfa11f5e66ed505ca9e152ba5ae0
+  revision: 439127fe5f784898fd390e2493ef527b60fed3b1
   branch: main
   specs:
     metadata_presenter (0.1.0)
       govspeak (>= 6.5.10)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
-      rails (~> 6.0.3, >= 6.0.3.4)
+      rails (>= 6.0.3.4, < 6.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -118,7 +118,7 @@ GEM
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
-    govuk_publishing_components (23.9.0)
+    govuk_publishing_components (23.10.0)
       govuk_app_config
       kramdown
       plek

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,8 +1,11 @@
 RSpec.feature 'Navigation' do
   let(:form) { ComplainAboutTribunal.new }
 
-  scenario 'when I navigate through the form' do
+  background do
     given_the_service_has_a_metadata
+  end
+
+  scenario 'when I navigate through the form' do
     when_I_visit_the_service
     and_I_add_my_full_name
     and_I_add_my_email
@@ -11,31 +14,12 @@ RSpec.feature 'Navigation' do
   end
 
   scenario 'when I visit a non existent page' do
-    given_the_service_has_a_metadata
     when_I_visit_a_non_existent_page
     then_I_should_see_not_found_page
   end
 
-  def given_the_service_has_a_metadata
-    expect(Rails.configuration.service_metadata).to eq(complain_about_tribunal_metadata)
-  end
-
-  def when_I_visit_the_service
-    form.load
-    form.start_button.click
-  end
-
   def when_I_visit_a_non_existent_page
     visit '/i-will-initiate-self-destruct'
-  end
-
-  def and_I_add_my_full_name
-    form.full_name_field.set('Han Solo')
-    form.continue_button.click
-  end
-
-  def and_I_add_my_email
-    form.email_field.set('han.solo@gmail.com')
   end
 
   def and_I_go_back_to_full_name_page
@@ -49,16 +33,6 @@ RSpec.feature 'Navigation' do
   def then_I_should_see_not_found_page
     expect(form.text).to include(
       "The page you were looking for doesn't exist (404)"
-    )
-  end
-
-  def complain_about_tribunal_metadata
-    JSON.parse(
-      File.read(
-        MetadataPresenter::Engine.root.join(
-          'spec', 'fixtures', 'version.json'
-        )
-      )
     )
   end
 end

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -1,0 +1,58 @@
+RSpec.feature 'Navigation' do
+  let(:form) { ComplainAboutTribunal.new }
+
+  background do
+    given_the_service_has_a_metadata
+    when_I_visit_the_service
+  end
+
+  scenario 'when required field is blank' do
+    and_I_left_my_name_blank
+    then_I_should_see_that_I_should_answer_my_name
+  end
+
+  scenario 'when minimum length field is too short' do
+    and_I_add_one_character_to_my_name
+    then_I_should_see_that_my_name_is_too_short
+  end
+
+  scenario 'when maximum length field is too large' do
+    and_I_add_many_characters_to_my_name
+    then_I_should_see_that_my_name_is_too_large
+  end
+
+  def and_I_left_my_name_blank
+    form.full_name_field.set('')
+    form.continue_button.click
+  end
+
+  def and_I_add_one_character_to_my_name
+    form.full_name_field.set('G')
+    form.continue_button.click
+  end
+
+  def and_I_add_many_characters_to_my_name
+    form.full_name_field.set('Gandalf Mithrandir the Wizard')
+    form.continue_button.click
+  end
+
+  def then_I_should_see_that_I_should_answer_my_name
+    expected_message = ['Enter an answer for Full name']
+    expect(form.error_summary).to eq(expected_message)
+    expect(form.error_messages).to eq(expected_message)
+  end
+
+  def then_I_should_see_that_my_name_is_too_short
+    expected_message =
+      ["Your answer for 'Full name' is too short (2 characters at least)"]
+    expect(form.error_summary).to eq(expected_message)
+    expect(form.error_messages).to eq(expected_message)
+  end
+
+  def then_I_should_see_that_my_name_is_too_large
+    expected_message =
+      ["Your answer for 'Full name' is too long (10 characters at most)"]
+    expect(form.error_summary).to eq(expected_message)
+    expect(form.error_messages).to eq(expected_message)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,51 +8,22 @@ require 'rspec/rails'
 require 'webmock/rspec'
 require 'capybara/rspec'
 Bundler.require(:development, :test)
-# Add additional requires below this line. Rails is not loaded until this point!
-
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
 Dir.glob("#{Rails.root}/spec/support/*/**/*.rb").sort.each { |f| require f }
 
 RSpec.configure do |config|
-  # Remove this line to enable support for ActiveRecord
   config.use_active_record = false
 
-  # If you enable ActiveRecord support you should unncomment these lines,
-  # note if you'd prefer not to run each example within a transaction, you
-  # should set use_transactional_fixtures to false.
-  #
-  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
-  # config.use_transactional_fixtures = true
-
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, type: :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
 
-  # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+  config.include FeatureSteps
+
+  config.after do |example_group|
+    if example_group.exception.present? &&
+        example_group.metadata[:type].to_sym.equal?(:feature)
+      puts '======================================='
+      puts form.text
+      puts '======================================='
+    end
+  end
 end

--- a/spec/support/helpers/feature_steps.rb
+++ b/spec/support/helpers/feature_steps.rb
@@ -1,0 +1,29 @@
+module FeatureSteps
+  def given_the_service_has_a_metadata
+    expect(Rails.configuration.service_metadata).to eq(complain_about_tribunal_metadata)
+  end
+
+  def and_I_add_my_full_name
+    form.full_name_field.set('Han Solo')
+    form.continue_button.click
+  end
+
+  def and_I_add_my_email
+    form.email_field.set('han.solo@gmail.com')
+  end
+
+  def when_I_visit_the_service
+    form.load
+    form.start_button.click
+  end
+
+  def complain_about_tribunal_metadata
+    JSON.parse(
+      File.read(
+        MetadataPresenter::Engine.root.join(
+          'spec', 'fixtures', 'version.json'
+        )
+      )
+    )
+  end
+end

--- a/spec/support/pages/complain_about_tribunal.rb
+++ b/spec/support/pages/complain_about_tribunal.rb
@@ -5,4 +5,19 @@ class ComplainAboutTribunal < SitePrism::Page
   element :full_name_field, :field, 'Full name'
   element :email_field, :field, 'Your email address'
   element :back_link, :link, 'Back'
+  elements :error_summary_list, '.govuk-error-summary__list'
+  elements :inline_error_messages, '.govuk-error-message'
+
+  def error_summary
+    error_summary_list.map(&:text)
+  end
+
+  def error_messages
+    ## gov-uk error messages adds a span inside span with
+    # visually hidden "Error: " which capybara shows
+    # independently if visible is true or false.
+    inline_error_messages.map do |error_message|
+      error_message.text.gsub('Error: ', '')
+    end
+  end
 end


### PR DESCRIPTION
## Context

This PR adds the feature specs for validation on the runner.

## Why I created as draft

It needs to merge the https://github.com/ministryofjustice/fb-metadata-presenter/pull/22 first in order to bundle and add the Gemfile and Gemfile.lock to this PR.