### PR TITLE
Add local start up instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,8 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
-
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+To run the project locally, execute the following steps:
+- Install Ruby dependencies `bundle install`
+- Install all dependencies `yarn install`
+- Bundle JavaScript assets `./bin/webpack`
+- Start the Rails server `bundle exec rails s`
+- The application should run on `localhost:3000`


### PR DESCRIPTION
Add instructions on how to start up the application locally.

We will need to add a lot more to the readme but this is to get us started so that developers can run the project locally and have a development environment to play with.