### PR TITLE
Specify remote docker version for CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,8 @@ jobs:
       - image: cimg/ruby:2.7.2
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: Setup containers
           command: make setup-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ ENV APP_PORT 3000
 EXPOSE $APP_PORT
 
 ARG RAILS_ENV=production
-RUN yarn install --check-files
+RUN yarn install --production --check-files
 RUN RAILS_ENV=${RAILS_ENV} SECRET_KEY_BASE=$(bin/rake secret) bundle exec rake assets:precompile --trace
 CMD bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0


### PR DESCRIPTION
If we do not specify the remote docker version CircleCI will default to use Docker 17.0.9. This version does not play nice with node versions 14.9.0 or later. Consequently it throws a EPERM: operation not permitted when trying to copy files.

Specifying a later Docker version aids in compatibility with node for now allows the yarn install to work correctly.

Also add the --production flag to install.

Co-authored-by: Matt Tei matt.tei@digital.justice.gov.uk