### PR TITLE
Check Answers

### DIFF
--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -54,9 +54,9 @@ RSpec.feature 'Navigation' do
   end
 
   def and_I_check_that_my_answers_are_correct
-    expect(form.full_name_summary.text).to include('Full name Han Solo')
-    expect(form.email_summary.text).to include('Your email address han.solo@gmail.com')
-    expect(form.parent_summary.text).to include('Parent name Unknown')
+    expect(form.full_name_checkanswers.text).to include('Full name Han Solo')
+    expect(form.email_checkanswers.text).to include('Your email address han.solo@gmail.com')
+    expect(form.parent_checkanswers.text).to include('Parent name Unknown')
   end
 
   def and_I_send_my_application
@@ -90,6 +90,6 @@ RSpec.feature 'Navigation' do
   end
 
   def then_I_should_see_my_changed_full_name_on_check_your_answers
-    expect(form.full_name_summary.text).to eq('Full name Jabba Change Your answer for Full name')
+    expect(form.full_name_checkanswers.text).to eq('Full name Jabba Change Your answer for Full name')
   end
 end

--- a/spec/support/pages/complain_about_tribunal.rb
+++ b/spec/support/pages/complain_about_tribunal.rb
@@ -27,19 +27,19 @@ class ComplainAboutTribunal < SitePrism::Page
     end
   end
 
-  def full_name_summary
+  def full_name_checkanswers
     summary_list[0]
   end
 
   def full_name_change_answer_link
-    full_name_summary.find('a')
+    full_name_checkanswers.find('a')
   end
 
-  def email_summary
+  def email_checkanswers
     summary_list[1]
   end
 
-  def parent_summary
+  def parent_checkanswers
     summary_list[2]
   end
 end


### PR DESCRIPTION
We have decided to change the Check Your Answers page schema from 'summary' to 'checkanswers'.
This aligns better with the GOVUK design systems: https://design-system.service.gov.uk/patterns/check-answers/

This change will help set the foundation for the story: https://trello.com/c/zp9OuUox/1196-backend-check-your-answers-page

The metadata-presenter has a corresponding PR: https://github.com/ministryofjustice/fb-metadata-presenter/pull/45