### PR TITLE
Add editable method in app controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,11 @@ class ApplicationController < ActionController::Base
     UserData.new(session).load_data
   end
 
+  def editable?
+    false
+  end
+  helper_method :editable?
+
   def answer_params
     params.permit(:answers => {})[:answers] || {}
   end


### PR DESCRIPTION
When we are on the editor pages/components could be editable but
not in the runner. This method is used on views in metadata presenter.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>