### PR TITLE
Add basic authentication before action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,8 @@
 class ApplicationController < ActionController::Base
+  if ENV['BASIC_AUTH_USER'].present? && ENV['BASIC_AUTH_PASS'].present?
+    http_basic_authenticate_with name: ENV['BASIC_AUTH_USER'], password: ENV['BASIC_AUTH_PASS']
+  end
+
   EXCEPTIONS = [
     UserDatastoreAdapter::DatastoreTimeoutError,
     UserDatastoreAdapter::DatastoreClientError

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,5 @@
 class ApplicationController < ActionController::Base
-  if ENV['BASIC_AUTH_USER'].present? && ENV['BASIC_AUTH_PASS'].present?
-    http_basic_authenticate_with name: ENV['BASIC_AUTH_USER'], password: ENV['BASIC_AUTH_PASS']
-  end
+  before_action :require_basic_auth
 
   EXCEPTIONS = [
     UserDatastoreAdapter::DatastoreTimeoutError,
@@ -32,5 +30,13 @@ class ApplicationController < ActionController::Base
 
   def answer_params
     params.permit(:answers => {})[:answers] || {}
+  end
+
+  def require_basic_auth
+    if ENV['BASIC_AUTH_USER'].present? && ENV['BASIC_AUTH_PASS'].present?
+      authenticate_or_request_with_http_basic do |username, password|
+        username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASS']
+      end
+    end
   end
 end

--- a/spec/controllers/health_controller_spec.rb
+++ b/spec/controllers/health_controller_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe HealthController do
+  describe 'GET #show' do
+    it 'returns 200 OK' do
+      get :show
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns healthy body' do
+      get :show
+      expect(response.body).to eq('healthy')
+    end
+  end
+end

--- a/spec/request/require_basic_auth_spec.rb
+++ b/spec/request/require_basic_auth_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe 'require basic auth', type: :request do
+  context 'when username and password exist' do
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('BASIC_AUTH_USER').and_return('somethinginteresting')
+      allow(ENV).to receive(:[]).with('BASIC_AUTH_PASS').and_return('somethingboring')
+    end
+
+    it 'returns forbidden' do
+      get '/'
+      expect(response.status).to eq(401)
+    end
+  end
+
+  context 'when username and/or password are not set' do
+    it 'returns success' do
+      get '/'
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
This adds the functionality to check whether basic authentication username and password exists

Also add spec for the health controller.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>

