### PR TITLE
Component/textarea

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ gem 'jwt'
 # one of these lines:
 # gem 'metadata_presenter',
 #     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'some-branch'
+#     branch: 'component/textarea'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.3.2'
+gem 'metadata_presenter', '0.6.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.1'
 gem 'sass-rails', '>= 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.3.2)
+    metadata_presenter (0.6.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -274,7 +274,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   jwt
   listen (~> 3.4)
-  metadata_presenter (= 0.3.2)
+  metadata_presenter (= 0.6.0)
   puma (~> 5.2)
   rails (~> 6.1.1)
   rspec-rails

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature 'Navigation' do
-  let(:form) { ComplainAboutTribunal.new }
+  let(:form) { VersionFixture.new }
 
   background do
     given_the_service_has_a_metadata

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_full_name
     and_I_add_my_email
     and_I_add_my_parent_info
+    and_I_add_my_family_hobbies
     and_I_check_that_my_answers_are_correct
     and_I_change_my_full_name_answer
     then_I_should_see_my_changed_full_name_on_check_your_answers
@@ -35,6 +36,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_full_name
     and_I_add_my_email
     and_I_add_my_parent_info
+    and_I_add_my_family_hobbies
     and_I_check_that_my_answers_are_correct
     and_I_send_my_application
     then_I_should_see_the_confirmation_message
@@ -53,10 +55,17 @@ RSpec.feature 'Navigation' do
     form.continue_button.click
   end
 
+  def and_I_add_my_family_hobbies
+    form.family_hobbies_field.set("Play with the dogs\n Surfing!")
+    form.continue_button.click
+  end
+
   def and_I_check_that_my_answers_are_correct
-    expect(form.full_name_checkanswers.text).to include('Full name Han Solo')
-    expect(form.email_checkanswers.text).to include('Your email address han.solo@gmail.com')
-    expect(form.parent_checkanswers.text).to include('Parent name Unknown')
+    expect(form.full_name_checkanswers.text).to include("Full name\nHan Solo")
+    expect(form.email_checkanswers.text).to include(
+      "Your email address\nhan.solo@gmail.com"
+    )
+    expect(form.parent_checkanswers.text).to include("Parent name\nUnknown")
   end
 
   def and_I_send_my_application
@@ -90,6 +99,8 @@ RSpec.feature 'Navigation' do
   end
 
   def then_I_should_see_my_changed_full_name_on_check_your_answers
-    expect(form.full_name_checkanswers.text).to eq('Full name Jabba Change Your answer for Full name')
+    expect(form.full_name_checkanswers.text).to eq(
+      "Full name\nJabba\nChange Your answer for Full name"
+    )
   end
 end

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -1,5 +1,5 @@
 RSpec.feature 'Navigation' do
-  let(:form) { ComplainAboutTribunal.new }
+  let(:form) { VersionFixture.new }
 
   background do
     given_the_service_has_a_metadata

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -1,10 +1,11 @@
-class ComplainAboutTribunal < SitePrism::Page
+class VersionFixture < SitePrism::Page
   set_url '/'
   element :start_button, :button, 'Start'
   element :continue_button, :button, 'Continue'
   element :full_name_field, :field, 'Full name'
   element :parent_field, :field, 'Parent name'
   element :email_field, :field, 'Your email address'
+  element :family_hobbies_field, :field, 'Your family hobbies'
   element :back_link, :link, 'Back'
   elements :error_summary_list, '.govuk-error-summary__list'
   elements :inline_error_messages, '.govuk-error-message'


### PR DESCRIPTION
[Trello Card](https://trello.com/c/0RfJqIH3/1234-add-textarea-component-to-a-single-question-page-backend)

## Context

This bumps the metadata presenter which added the textarea component.

Since in the gem we changed the 'version.json' fixture we need to add the step on the feature tests as well.