### PR TITLE
Add acceptance tests for number component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ gem 'faraday_middleware'
 gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-     github: 'ministryofjustice/fb-metadata-presenter',
-     branch: 'component/number'
+#gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-#gem 'metadata_presenter', '0.7.1'
+gem 'metadata_presenter', '0.8.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.1'
 gem 'sass-rails', '>= 6'

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ gem 'faraday_middleware'
 gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-#gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'fix/runner'
+gem 'metadata_presenter',
+     github: 'ministryofjustice/fb-metadata-presenter',
+     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.7.1'
+#gem 'metadata_presenter', '0.7.1'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.1'
 gem 'sass-rails', '>= 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 2c60bf747dcf6ce0bd0d106025f6f973201c1602
-  branch: component/number
-  specs:
-    metadata_presenter (0.8.0)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -109,7 +98,7 @@ GEM
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_design_system_formbuilder (2.1.7)
+    govuk_design_system_formbuilder (2.1.8)
       actionview (>= 5.2)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
@@ -132,6 +121,11 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    metadata_presenter (0.8.0)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
@@ -280,7 +274,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   jwt
   listen (~> 3.4)
-  metadata_presenter!
+  metadata_presenter (= 0.8.0)
   puma (~> 5.2)
   rails (~> 6.1.1)
   rspec-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 2c60bf747dcf6ce0bd0d106025f6f973201c1602
+  branch: component/number
+  specs:
+    metadata_presenter (0.8.0)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -121,11 +132,6 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
@@ -274,7 +280,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   jwt
   listen (~> 3.4)
-  metadata_presenter (= 0.7.1)
+  metadata_presenter!
   puma (~> 5.2)
   rails (~> 6.1.1)
   rspec-rails

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - 9000:3000
     environment:
-      RAILS_ENV: development
+      RAILS_ENV: test
       RAILS_LOG_TO_STDOUT: 'true'
       SECRET_KEY_BASE: '8917f6fa9a96e678f4777aea2bf148920a325162da1bd7b246baba4437eec8176765be27156161086abfe91266dfdc8a851d3e97edb66fe9f27ba4ea09bdc142'
       SERVICE_FIXTURE: 'version'

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_full_name
     and_I_add_my_email
     and_I_add_my_parent_info
+    and_I_add_my_age
     and_I_add_my_family_hobbies
     and_I_check_that_my_answers_are_correct
     and_I_change_my_full_name_answer
@@ -36,6 +37,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_full_name
     and_I_add_my_email
     and_I_add_my_parent_info
+    and_I_add_my_age
     and_I_add_my_family_hobbies
     and_I_check_that_my_answers_are_correct
     and_I_send_my_application
@@ -55,8 +57,15 @@ RSpec.feature 'Navigation' do
     form.continue_button.click
   end
 
+  def and_I_add_my_age
+    form.age_field.set('31')
+    form.continue_button.click
+  end
+
   def and_I_add_my_family_hobbies
-    form.family_hobbies_field.set("Play with the dogs\n Surfing!")
+    form.family_hobbies_field.set(
+      "Play with the dogs\r\nSurfing!" # emulates textarea carriage return
+    )
     form.continue_button.click
   end
 
@@ -66,6 +75,10 @@ RSpec.feature 'Navigation' do
       "Your email address\nhan.solo@gmail.com"
     )
     expect(form.parent_checkanswers.text).to include("Parent name\nUnknown")
+    expect(form.age_checkanswers.text).to include("Your age\n31")
+    expect(form.family_hobbies_checkanswers.text).to include(
+      "Your family hobbies\nPlay with the dogs\nSurfing!"
+    )
   end
 
   def and_I_send_my_application

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -21,6 +21,12 @@ RSpec.feature 'Navigation' do
     then_I_should_see_that_my_name_is_too_large
   end
 
+  scenario 'when number field is not a number' do
+    and_I_visit_my_age_page
+    when_I_add_an_invalid_age
+    then_I_should_see_that_I_should_enter_a_number
+  end
+
   def and_I_left_my_name_blank
     form.full_name_field.set('')
     form.continue_button.click
@@ -36,22 +42,41 @@ RSpec.feature 'Navigation' do
     form.continue_button.click
   end
 
+  def and_I_visit_my_age_page
+    visit '/your-age'
+  end
+
+  def when_I_add_an_invalid_age
+    form.age_field.set('Millenium Falcon')
+    form.continue_button.click
+  end
+
   def then_I_should_see_that_I_should_answer_my_name
-    expected_message = ['Enter an answer for Full name']
-    expect(form.error_summary).to eq(expected_message)
-    expect(form.error_messages).to eq(expected_message)
+    then_I_should_see_the_error_message(
+      'Enter an answer for Full name'
+    )
   end
 
   def then_I_should_see_that_my_name_is_too_short
-    expected_message =
-      ["Your answer for 'Full name' is too short (2 characters at least)"]
-    expect(form.error_summary).to eq(expected_message)
-    expect(form.error_messages).to eq(expected_message)
+    then_I_should_see_the_error_message(
+      "Your answer for 'Full name' is too short (2 characters at least)"
+    )
   end
 
   def then_I_should_see_that_my_name_is_too_large
-    expected_message =
-      ["Your answer for 'Full name' is too long (10 characters at most)"]
+    then_I_should_see_the_error_message(
+      "Your answer for 'Full name' is too long (10 characters at most)"
+    )
+  end
+
+  def then_I_should_see_that_I_should_enter_a_number
+    then_I_should_see_the_error_message(
+      'Enter a number for Your age'
+    )
+  end
+
+  def then_I_should_see_the_error_message(message)
+    expected_message = [message]
     expect(form.error_summary).to eq(expected_message)
     expect(form.error_messages).to eq(expected_message)
   end

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -27,6 +27,12 @@ RSpec.feature 'Navigation' do
     then_I_should_see_that_I_should_enter_a_number
   end
 
+  scenario 'when number field is blank and it is required' do
+    and_I_visit_my_age_page
+    when_I_left_my_age_blank
+    then_I_should_see_that_I_should_answer_my_age
+  end
+
   def and_I_left_my_name_blank
     form.full_name_field.set('')
     form.continue_button.click
@@ -51,9 +57,20 @@ RSpec.feature 'Navigation' do
     form.continue_button.click
   end
 
+  def when_I_left_my_age_blank
+    form.age_field.set('')
+    form.continue_button.click
+  end
+
   def then_I_should_see_that_I_should_answer_my_name
     then_I_should_see_the_error_message(
       'Enter an answer for Full name'
+    )
+  end
+
+  def then_I_should_see_that_I_should_answer_my_age
+    then_I_should_see_the_error_message(
+      'Enter an answer for Your age'
     )
   end
 

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -5,6 +5,7 @@ class VersionFixture < SitePrism::Page
   element :full_name_field, :field, 'Full name'
   element :parent_field, :field, 'Parent name'
   element :email_field, :field, 'Your email address'
+  element :age_field, :field, 'Your age'
   element :family_hobbies_field, :field, 'Your family hobbies'
   element :back_link, :link, 'Back'
   elements :error_summary_list, '.govuk-error-summary__list'
@@ -42,5 +43,13 @@ class VersionFixture < SitePrism::Page
 
   def parent_checkanswers
     summary_list[2]
+  end
+
+  def age_checkanswers
+    summary_list[3]
+  end
+
+  def family_hobbies_checkanswers
+    summary_list[4]
   end
 end


### PR DESCRIPTION
## Context

This adds the acceptance tests for the number component.

The implementation can seem in the gem: https://github.com/ministryofjustice/fb-metadata-presenter/pull/57

## Do not review until the metadata presenter PR is merged

We need to wait for the metadata presenter PR to be merged so we can update the Gemfile to use the version instead of the branch.