### PR TITLE
Components/radio buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jwt'
 #     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.8.0'
+gem 'metadata_presenter', '0.11.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.1'
 gem 'sass-rails', '>= 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.8.0)
+    metadata_presenter (0.11.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -274,7 +274,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   jwt
   listen (~> 3.4)
-  metadata_presenter (= 0.8.0)
+  metadata_presenter (= 0.11.0)
   puma (~> 5.2)
   rails (~> 6.1.1)
   rspec-rails

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_parent_info
     and_I_add_my_age
     and_I_add_my_family_hobbies
+    and_I_declare_my_dislike_of_star_wars
     and_I_check_that_my_answers_are_correct
     and_I_change_my_full_name_answer
     then_I_should_see_my_changed_full_name_on_check_your_answers
@@ -39,6 +40,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_parent_info
     and_I_add_my_age
     and_I_add_my_family_hobbies
+    and_I_declare_my_dislike_of_star_wars
     and_I_check_that_my_answers_are_correct
     and_I_send_my_application
     then_I_should_see_the_confirmation_message
@@ -69,6 +71,11 @@ RSpec.feature 'Navigation' do
     form.continue_button.click
   end
 
+  def and_I_declare_my_dislike_of_star_wars
+    form.hell_no.click
+    form.continue_button.click
+  end
+
   def and_I_check_that_my_answers_are_correct
     expect(form.full_name_checkanswers.text).to include("Full name\nHan Solo")
     expect(form.email_checkanswers.text).to include(
@@ -79,6 +86,7 @@ RSpec.feature 'Navigation' do
     expect(form.family_hobbies_checkanswers.text).to include(
       "Your family hobbies\nPlay with the dogs\nSurfing!"
     )
+    expect(form.do_you_like_star_wars_checkanswers.text).to include("Hell no!")
   end
 
   def and_I_send_my_application

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -33,6 +33,12 @@ RSpec.feature 'Navigation' do
     then_I_should_see_that_I_should_answer_my_age
   end
 
+  scenario 'when no radio button is selected and it is required' do
+    and_I_visit_the_radio_buttons_page
+    when_I_did_not_choose_a_radio_button
+    then_I_should_see_that_I_should_choose_a_radio_option
+  end
+
   def and_I_left_my_name_blank
     form.full_name_field.set('')
     form.continue_button.click
@@ -52,6 +58,10 @@ RSpec.feature 'Navigation' do
     visit '/your-age'
   end
 
+  def and_I_visit_the_radio_buttons_page
+    visit '/do-you-like-star-wars'
+  end
+
   def when_I_add_an_invalid_age
     form.age_field.set('Millenium Falcon')
     form.continue_button.click
@@ -59,6 +69,10 @@ RSpec.feature 'Navigation' do
 
   def when_I_left_my_age_blank
     form.age_field.set('')
+    form.continue_button.click
+  end
+
+  def when_I_did_not_choose_a_radio_button
     form.continue_button.click
   end
 
@@ -89,6 +103,12 @@ RSpec.feature 'Navigation' do
   def then_I_should_see_that_I_should_enter_a_number
     then_I_should_see_the_error_message(
       'Enter a number for Your age'
+    )
+  end
+
+  def then_I_should_see_that_I_should_choose_a_radio_option
+    then_I_should_see_the_error_message(
+      'Enter an answer for Do you like Star Wars?'
     )
   end
 

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -7,6 +7,7 @@ class VersionFixture < SitePrism::Page
   element :email_field, :field, 'Your email address'
   element :age_field, :field, 'Your age'
   element :family_hobbies_field, :field, 'Your family hobbies'
+  element :hell_no, :radio_button, 'Hell no!'
   element :back_link, :link, 'Back'
   elements :error_summary_list, '.govuk-error-summary__list'
   elements :inline_error_messages, '.govuk-error-message'
@@ -51,5 +52,9 @@ class VersionFixture < SitePrism::Page
 
   def family_hobbies_checkanswers
     summary_list[4]
+  end
+
+  def do_you_like_star_wars_checkanswers
+    summary_list[5]
   end
 end


### PR DESCRIPTION
## Add navigation acceptance tests for the radio buttons

The radio buttons component has now been added to the presenter so this updates the navigation specs to include the new page in the fixture.

## Update validation spec to include the radio buttons

## Metadata Presenter v0.11.0

https://trello.com/c/vo4dqCu4/1237-add-radio-buttons-component-to-a-single-question-page