### PR TITLE
Navigation and validation specs for checkbox component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jwt'
 #     branch: 'component/number'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.12.1'
+gem 'metadata_presenter', '0.13.1'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.1'
 gem 'sass-rails', '>= 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.12.1)
+    metadata_presenter (0.13.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -274,7 +274,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.5.0)
   jwt
   listen (~> 3.4)
-  metadata_presenter (= 0.12.1)
+  metadata_presenter (= 0.13.1)
   puma (~> 5.2)
   rails (~> 6.1.1)
   rspec-rails

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_family_hobbies
     and_I_declare_my_dislike_of_star_wars
     and_I_add_my_holiday
+    and_I_add_my_burger
     and_I_check_that_my_answers_are_correct
     and_I_change_my_full_name_answer
     then_I_should_see_my_changed_full_name_on_check_your_answers
@@ -43,6 +44,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_family_hobbies
     and_I_declare_my_dislike_of_star_wars
     and_I_add_my_holiday
+    and_I_add_my_burger
     and_I_check_that_my_answers_are_correct
     and_I_send_my_application
     then_I_should_see_the_confirmation_message
@@ -60,6 +62,13 @@ RSpec.feature 'Navigation' do
     and_I_add_my_holiday
     and_I_go_back
     then_I_should_see_my_holiday_in_the_fields
+  end
+
+  scenario 'when I go back to a page with a checkbox component' do
+    and_I_go_to_burger_page
+    and_I_add_my_burger
+    and_I_go_back
+    then_I_should_see_cheese_chicken_chosen
   end
 
   def when_I_visit_a_non_existent_page
@@ -99,6 +108,12 @@ RSpec.feature 'Navigation' do
     and_I_go_to_next_page
   end
 
+  def and_I_add_my_burger
+    form.cheeseburger.click
+    form.chicken_burger.click
+    and_I_go_to_next_page
+  end
+
   def and_I_check_that_my_answers_are_correct
     expect(form.full_name_checkanswers.text).to include("Full name Han Solo")
     expect(form.email_checkanswers.text).to include(
@@ -110,6 +125,7 @@ RSpec.feature 'Navigation' do
       "Your family hobbies\nPlay with the dogs\nSurfing!"
     )
     expect(form.do_you_like_star_wars_checkanswers.text).to include("Hell no!")
+    expect(form.burger_checkanswers.text).to include("Mozzarella, cheddar, feta")
     expect(form.holiday_checkanswers.text).to eq(
       'What is the day that you like to take holidays? 01 June 2021 Change Your answer for What is the day that you like to take holidays?'
     )
@@ -160,5 +176,11 @@ RSpec.feature 'Navigation' do
   def then_I_should_hell_no_option_chosen
     expect(form.only_on_weekends).to_not be_checked
     expect(form.hell_no).to be_checked
+  end
+
+  def then_I_should_see_cheese_chicken_chosen
+    expect(form.beef_burger).to_not be_checked
+    expect(form.chicken_burger).to be_checked
+    expect(form.cheeseburger).to be_checked
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -122,7 +122,7 @@ RSpec.feature 'Navigation' do
     expect(form.parent_checkanswers.text).to include("Parent name Unknown")
     expect(form.age_checkanswers.text).to include("Your age 31")
     expect(form.family_hobbies_checkanswers.text).to include(
-      "Your family hobbies\nPlay with the dogs\nSurfing!"
+      "Your family hobbies Play with the dogs Surfing! Change Your answer for Your family hobbies"
     )
     expect(form.do_you_like_star_wars_checkanswers.text).to include("Hell no!")
     expect(form.burger_checkanswers.text).to include("Mozzarella, cheddar, feta")

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -39,6 +39,12 @@ RSpec.feature 'Navigation' do
     then_I_should_see_that_I_should_choose_a_radio_option
   end
 
+  scenario 'when no checkbox is selected and it is required' do
+    and_I_go_to_burger_page
+    when_I_do_not_choose_a_checkbox
+    then_I_should_see_choose_a_checkbox
+  end
+
   scenario 'when date field is totally blank' do
     and_I_go_to_my_holiday_page
     and_I_go_to_next_page
@@ -115,6 +121,10 @@ RSpec.feature 'Navigation' do
     and_I_go_to_next_page
   end
 
+  def when_I_do_not_choose_a_checkbox
+    and_I_go_to_next_page
+  end
+
   def then_I_should_see_that_I_should_answer_my_name
     then_I_should_see_the_error_message(
       'Enter an answer for Full name'
@@ -160,6 +170,12 @@ RSpec.feature 'Navigation' do
   def then_I_should_see_that_I_should_add_a_valid_holiday
     then_I_should_see_the_error_message(
       'Enter a valid date for What is the day that you like to take holidays?'
+    )
+  end
+
+  def then_I_should_see_choose_a_checkbox
+    then_I_should_see_the_error_message(
+      'Enter an answer for What would you like on your burger?'
     )
   end
 

--- a/spec/support/helpers/feature_steps.rb
+++ b/spec/support/helpers/feature_steps.rb
@@ -25,6 +25,10 @@ module FeatureSteps
     visit '/do-you-like-star-wars'
   end
 
+  def and_I_go_to_burger_page
+    visit '/burgers'
+  end
+
   def when_I_visit_the_service
     form.load
     form.start_button.click

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -12,6 +12,9 @@ class VersionFixture < SitePrism::Page
   element :holiday_day_field, :field, 'Day'
   element :holiday_month_field, :field, 'Month'
   element :holiday_year_field, :field, 'Year'
+  element :cheeseburger, :checkbox, 'Mozzarella, cheddar, feta'
+  element :beef_burger, :checkbox, 'Beef, cheese, tomato'
+  element :chicken_burger, :checkbox, 'Chicken, cheese, tomato'
   element :back_link, :link, 'Back'
   elements :error_summary_list, '.govuk-error-summary__list'
   elements :inline_error_messages, '.govuk-error-message'
@@ -64,5 +67,9 @@ class VersionFixture < SitePrism::Page
 
   def holiday_checkanswers
     summary_list[6]
+  end
+
+  def burger_checkanswers
+    summary_list[7]
   end
 end


### PR DESCRIPTION
Story: https://trello.com/c/eOQZs8J2/1238-add-checkboxes-component-to-a-single-question-page

Add navigation acceptance tests and update validation specs to include checkboxes.

Also had to change the textarea navigation spec to allow them to pass. 

Note: the presenter will need to be merged before these will pass: https://github.com/ministryofjustice/fb-metadata-presenter/pull/66