### PR TITLE
Update user datastore load testing script

### DIFF
--- a/bin/load_test_datastore
+++ b/bin/load_test_datastore
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 
-number_of_requests=100
-concurrency=100
-
 access_token=$1
 domain=$2
 user_identifier=$3
 slug=$4
+concurrency=$5
+duration=$6
 
 if [[ -z $domain ]]; then
   domain="http://localhost:10001"
@@ -21,15 +20,15 @@ url="${domain}/service/${slug}/user/$user_identifier"
 
 echo "======= Vegeta Attack for 'POST ${url}' =========="
   echo "POST $url" | \
-  vegeta attack -rate=150 -header "x-access-token-v2: ${access_token}" \
+  vegeta attack -rate="${concurrency}" -header "x-access-token-v2: ${access_token}" \
   -body "./bin/datastore_request_body" \
-  -duration=20s | \
+  -duration="${duration}s" | \
   tee results.bin | \
   vegeta report
 
 echo "======= Vegeta Attack for 'GET ${url}' =========="
 echo "GET $url" | \
-  vegeta attack --rate=150 -header "x-access-token-v2: ${access_token}" \
-  -duration=20s | \
+  vegeta attack --rate="${concurrency}" -header "x-access-token-v2: ${access_token}" \
+  -duration="${duration}s" | \
   tee results.bin | \
   vegeta report

--- a/lib/tasks/load_test_datastore.rake
+++ b/lib/tasks/load_test_datastore.rake
@@ -2,10 +2,12 @@ namespace :load_test do
   desc "
   Load test the datastore
   Usage
-  rake load_test:engage[service_slug]
+  rake load_test:engage[service_slug,3000,30]
   "
-  task :engage, [:slug] => :environment do |_t, args|
+  task :engage, [:slug, :concurrency, :duration] => :environment do |_t, args|
     slug = args[:slug]
+    concurrency = args[:concurrency] || 150
+    duration = args[:duration] || 25
 
     Fb::Jwt::Auth.configure do |config|
       config.issuer = slug
@@ -18,6 +20,6 @@ namespace :load_test do
       subject: subject
     ).generate
 
-    system("'#{Rails.root.join('bin', 'load_test_datastore')}' '#{token}' '#{ENV['DATASTORE_URL']}' '#{subject}' '#{slug}'")
+    system("'#{Rails.root.join('bin', 'load_test_datastore')}' '#{token}' '#{ENV['USER_DATASTORE_URL']}' '#{subject}' '#{slug}' '#{concurrency}' '#{duration}'")
   end
 end


### PR DESCRIPTION
We want to be able to set the concurrency (concurrent users) and the
duration to different things and pass them in as parameters to the
script.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>