### PR TITLE
Fix incorrect width of confirmation box

### DIFF
--- a/app/javascript/packs/stylesheets/govuk.scss
+++ b/app/javascript/packs/stylesheets/govuk.scss
@@ -1,2 +1,13 @@
 $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "govuk-frontend/govuk/all";
+
+// Corrective tweak to make area non-full width in large view
+// Pointed out by design and shown in this example (at time of writing)
+// https://design-system.service.gov.uk/patterns/confirmation-pages/default/index.html 
+.govuk-panel--confirmation {
+  width: govuk-grid-width("two-thirds");
+
+  @include govuk-media-query($until: tablet) {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
**Was**
<img width="1084" alt="Screenshot 2021-03-02 at 14 51 28" src="https://user-images.githubusercontent.com/76942244/109666160-d841be80-7b66-11eb-814a-b664d9abad04.png">

(designer says should be)
**Now**
<img width="1081" alt="Screenshot 2021-03-02 at 14 51 37" src="https://user-images.githubusercontent.com/76942244/109666240-e98acb00-7b66-11eb-9d30-25153038e730.png">
