### PR TITLE
Add support for multiple questions pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jwt'
 #     branch: 'submissions-v2'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.15.3'
+gem 'metadata_presenter', '0.16.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.3'
 gem 'sass-rails', '>= 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.15.3)
+    metadata_presenter (0.16.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -279,7 +279,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   jwt
   listen (~> 3.4)
-  metadata_presenter (= 0.15.3)
+  metadata_presenter (= 0.16.0)
   puma (~> 5.2)
   rails (~> 6.1.3)
   rspec-rails

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -51,7 +51,7 @@ module Platform
         next if page.components.blank?
 
         {
-          heading: '',
+          heading: heading(page),
           answers: page.components.map do |component|
             {
               field_id: component.id,
@@ -76,6 +76,10 @@ module Platform
       else
         answer
       end
+    end
+
+    def heading(page)
+      page.type == 'page.multiplequestions' ? page.heading : ''
     end
   end
 end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -25,6 +25,7 @@ RSpec.feature 'Navigation' do
     and_I_declare_my_dislike_of_star_wars
     and_I_add_my_holiday
     and_I_add_my_burger
+    and_I_add_my_star_wars_knowledge
     and_I_check_that_my_answers_are_correct
     and_I_change_my_full_name_answer
     then_I_should_see_my_changed_full_name_on_check_your_answers
@@ -45,6 +46,7 @@ RSpec.feature 'Navigation' do
     and_I_declare_my_dislike_of_star_wars
     and_I_add_my_holiday
     and_I_add_my_burger
+    and_I_add_my_star_wars_knowledge
     and_I_check_that_my_answers_are_correct
     and_I_send_my_application
     then_I_should_see_the_confirmation_message
@@ -114,6 +116,12 @@ RSpec.feature 'Navigation' do
     and_I_go_to_next_page
   end
 
+  def and_I_add_my_star_wars_knowledge
+    form.palace_band.set('Max Rebo Band')
+    form.mando_name.click
+    and_I_go_to_next_page
+  end
+
   def and_I_check_that_my_answers_are_correct
     expect(form.full_name_checkanswers.text).to include("Full name Han Solo")
     expect(form.email_checkanswers.text).to include(
@@ -128,6 +136,13 @@ RSpec.feature 'Navigation' do
     expect(form.burger_checkanswers.text).to include("Mozzarella, cheddar, feta")
     expect(form.holiday_checkanswers.text).to eq(
       'What is the day that you like to take holidays? 01 June 2021 Change Your answer for What is the day that you like to take holidays?'
+    )
+    expect(form.multiple_questions_heading.text).to include('How well do you know Star Wars?')
+    expect(form.star_wars_knowledge_1_checkanswers.text).to include(
+      "What was the name of the band playing in Jabba's palace? Max Rebo Band Change Your answer for What was the name of the band playing in Jabba's palace?"
+    )
+    expect(form.star_wars_knowledge_2_checkanswers.text).to include(
+      "What is The Mandalorian's real name? Din Jarrin Change Your answer for What is The Mandalorian's real name?"
     )
   end
 

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe Platform::SubmitterPayload do
       'holiday_date_1(3i)' => '30',
       'holiday_date_1(2i)' => '12',
       'holiday_date_1(1i)' => '2020',
-      'burgers_checkboxes_1' => ['Beef, cheese, tomato', 'Chicken, cheese, tomato']
+      'burgers_checkboxes_1' => ['Beef, cheese, tomato', 'Chicken, cheese, tomato'],
+      'star-wars-knowledge_text_1' => "Max Rebo Band",
+      'star-wars-knowledge_radios_1' => "Din Jarrin"
     }
   end
   let(:pdf_heading) do
@@ -115,6 +117,21 @@ RSpec.describe Platform::SubmitterPayload do
             field_id: "burgers_checkboxes_1",
             field_name: "What would you like on your burger?",
             answer: ['Beef, cheese, tomato', 'Chicken, cheese, tomato']
+          }
+        ]
+      },
+      {
+        heading: 'How well do you know Star Wars?',
+        answers: [
+          {
+            field_id: "star-wars-knowledge_text_1",
+            field_name: "What was the name of the band playing in Jabba's palace?",
+            answer: "Max Rebo Band"
+          },
+          {
+            field_id: "star-wars-knowledge_radios_1",
+            field_name: "What is The Mandalorian's real name?",
+            answer: "Din Jarrin"
           }
         ]
       }

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -15,7 +15,10 @@ class VersionFixture < SitePrism::Page
   element :cheeseburger, :checkbox, 'Mozzarella, cheddar, feta'
   element :beef_burger, :checkbox, 'Beef, cheese, tomato'
   element :chicken_burger, :checkbox, 'Chicken, cheese, tomato'
+  element :palace_band, :field, "What was the name of the band playing in Jabba's palace?"
+  element :mando_name, :radio_button, 'Din Jarrin'
   element :back_link, :link, 'Back'
+  element :multiple_questions_heading, 'h3'
   elements :error_summary_list, '.govuk-error-summary__list'
   elements :inline_error_messages, '.govuk-error-message'
   elements :summary_list, '.govuk-summary-list__row'
@@ -71,5 +74,13 @@ class VersionFixture < SitePrism::Page
 
   def burger_checkanswers
     summary_list[7]
+  end
+
+  def star_wars_knowledge_1_checkanswers
+    summary_list[8]
+  end
+
+  def star_wars_knowledge_2_checkanswers
+    summary_list[9]
   end
 end


### PR DESCRIPTION
This adds the ability for the Runner to display and submit multiple questions pages.

Updated the submitter payload to reference the page heading as well.

Use metadata presenter 0.16.0

https://trello.com/c/ZiXnSx8Q/1335-multi-question-page