### PR TITLE
Email submission config

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -38,7 +38,7 @@ module Platform
         {
           kind: EMAIL,
           to: ENV['SERVICE_EMAIL_OUTPUT'],
-          from: ENV['SERVICE_EMAIL_SENDER'],
+          from: ENV['SERVICE_EMAIL_FROM'],
           subject: ENV['SERVICE_EMAIL_SUBJECT'],
           email_body: ENV['SERVICE_EMAIL_BODY'],
           include_pdf: true

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -29,7 +29,7 @@ module Platform
     def meta
       {
         pdf_heading: ENV['SERVICE_EMAIL_PDF_HEADING'],
-        pdf_subheading: ENV['SERVICE_EMAIL_PDF_SUBHEADING']
+        pdf_subheading: ENV['SERVICE_EMAIL_PDF_SUBHEADING'].to_s
       }
     end
 

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Platform::SubmitterPayload do
     "Middle Earth characters"
   end
   let(:pdf_subheading) do
-    "Gossip magazine about middle earth characters"
+    nil
   end
   let(:email_to) do
     "middle.earth.entertainment@magazine.co.uk"
@@ -146,12 +146,6 @@ RSpec.describe Platform::SubmitterPayload do
         name: service.service_name
       }
     end
-    let(:meta_payload) do
-      {
-        pdf_heading: pdf_heading,
-        pdf_subheading: pdf_subheading
-      }
-    end
     let(:actions_payload) do
       [
         {
@@ -185,16 +179,27 @@ RSpec.describe Platform::SubmitterPayload do
       expect(submitter_payload.to_h[:service]).to eq(service_payload)
     end
 
-    it 'sends meta info' do
-      expect(submitter_payload.to_h[:meta]).to eq(meta_payload)
-    end
-
     it 'sends actions info' do
       expect(submitter_payload.to_h[:actions]).to eq(actions_payload)
     end
 
     it 'sends pages info' do
       expect(submitter_payload.to_h[:pages]).to eq(pages_payload)
+    end
+
+    describe '#meta_payload' do
+      it 'SERVICE_EMAIL_PDF_SUBHEADING defaults to an empty string' do
+        expect(submitter_payload.to_h[:meta][:pdf_subheading]).to eq("")
+      end
+
+      it 'sends meta info' do
+        expect(submitter_payload.to_h[:meta]).to eq(
+          {
+            :pdf_heading=>pdf_heading,
+            :pdf_subheading=>""
+            }
+          )
+      end
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe Platform::SubmitterPayload do
         .and_return(pdf_subheading)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_OUTPUT')
         .and_return(email_to)
-      allow(ENV).to receive(:[]).with('SERVICE_EMAIL_SENDER')
+      allow(ENV).to receive(:[]).with('SERVICE_EMAIL_FROM')
         .and_return(email_from)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_SUBJECT')
         .and_return(email_subject)


### PR DESCRIPTION
Relates to story: https://trello.com/c/utAUt3qG/1253-add-submission-configuration-serviceoutputemail-to-editor

At present, the PDF_SUBHEADING can be left blank in the email submission settings form.
The editor will detect this and remove the PDF_SUBHEADING value from the database.
This means the submitter will throw an 'Unproccessable entity' error as pdf_subheading is nil, rendering the schema invalid and the submission will not be processed.

This commit ensures the value of PDF_SUBHEADING will not be nil but instead an empty string.

Ideally, this change would be done in the editor as this is where all the email submission settings live, but we could not find an easy way to do this.