### PR TITLE
Add required sentry gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'rails', '~> 6.1.3'
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.2'
 gem 'fb-jwt-auth', '0.6.0'
+gem 'sentry-ruby', '~> 4.3.0'
+gem 'sentry-rails', '~> 4.3.1'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,16 @@ GEM
       sprockets-rails
       tilt
     semantic_range (2.3.1)
+    sentry-rails (4.3.1)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -284,6 +294,8 @@ DEPENDENCIES
   rails (~> 6.1.3)
   rspec-rails
   sass-rails (>= 6)
+  sentry-rails (~> 4.3.1)
+  sentry-ruby (~> 4.3.0)
   simplecov
   simplecov-console
   site_prism

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   ]
   rescue_from(*EXCEPTIONS) do |exception|
     Rails.logger.info(exception.message)
+    Sentry.capture_exception(exception)
     render file: 'public/500.html', status: 500
   end
   layout 'metadata_presenter/application'

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,3 +33,13 @@ module FbRunner
     config.generators.system_tests = nil
   end
 end
+
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger]
+
+  config.before_send = lambda do |event, _hint|
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    event.request.data = filter.filter(event.request.data)
+    event
+  end
+end


### PR DESCRIPTION
SENTRY_DSN is injected by the editor. This environment variable is looked for by default so need to explicitly set it.

This version of sentry uses the config flag send_default_pii to decide sensitive data to be sent. This is set to false by default. This only covers the following:

- user ip address
- user cookie
- request body

Further parameters are filtered in the Sentry configuration.