### PR TITLE
Cater for standard errors in Sentry

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,10 @@ Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger]
 
   config.before_send = lambda do |event, _hint|
-    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
-    event.request.data = filter.filter(event.request.data)
+    if event.request && event.request.data
+      filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+      event.request.data = filter.filter(event.request.data)
+    end
     event
   end
 end


### PR DESCRIPTION
Not all events will have request objects, sometimes they will just be error classes.


![Screenshot 2021-03-22 at 13 20 39](https://user-images.githubusercontent.com/3466862/112003481-da20f100-8b18-11eb-9476-ad928472977c.png)
