### PR TITLE
Validate service metadata on startup

### DIFF
--- a/app/services/load_service_metadata.rb
+++ b/app/services/load_service_metadata.rb
@@ -9,14 +9,26 @@ class LoadServiceMetadata
   end
 
   def to_h
-    if @service_metadata.blank? && File.exist?(@fixture)
-      puts("Loading fixture #{@fixture}")
-      return JSON.parse(File.read(@fixture))
+    if metadata_to_load
+      return metadata_to_load if valid_metadata?
     end
 
-    return JSON.parse(@service_metadata) if @service_metadata.present?
-
     raise ServiceMetadataNotFoundError.new(error_message) unless @asset_precompile.present?
+  end
+
+  def metadata_to_load
+    @_metadata_to_load ||= begin
+      if @service_metadata.blank? && File.exist?(@fixture)
+        puts("Loading fixture #{@fixture}")
+        return JSON.parse(File.read(@fixture))
+      end
+
+      return JSON.parse(@service_metadata) if @service_metadata.present?
+    end
+  end
+
+  def valid_metadata?
+    MetadataPresenter::ValidateSchema.validate(metadata_to_load, 'service.base')
   end
 
   def error_message

--- a/spec/services/load_service_metadata_spec.rb
+++ b/spec/services/load_service_metadata_spec.rb
@@ -3,16 +3,21 @@ RSpec.describe LoadServiceMetadata do
 
   describe '#to_h' do
     context 'when service metadata is present' do
+      let(:service_metadata) do
+        File.read(
+          MetadataPresenter::Engine.root.join('fixtures', 'service.json')
+        )
+      end
       let(:attributes) do
         {
-          service_metadata: %{{ "service_name": "Luke" }},
+          service_metadata: service_metadata,
           fixture: nil,
           asset_precompile: nil
         }
       end
 
       it 'returns the service metadata' do
-        expect(load_service_metadata.to_h).to eq({ 'service_name' => 'Luke' })
+        expect(load_service_metadata.to_h).to eq(JSON.parse(service_metadata))
       end
     end
 
@@ -63,6 +68,22 @@ RSpec.describe LoadServiceMetadata do
             }.to raise_error(LoadServiceMetadata::ServiceMetadataNotFoundError)
           end
         end
+      end
+    end
+
+    context 'when metadata is invalid' do
+      let(:attributes) do
+        {
+          service_metadata: %{{ "service_name": "Luke" }},
+          fixture: nil,
+          asset_precompile: nil
+        }
+      end
+
+      it 'raises JSON schema validation error' do
+        expect {
+          load_service_metadata.to_h
+        }.to raise_error(JSON::Schema::ValidationError)
       end
     end
   end


### PR DESCRIPTION
We do not want the runner to start up at all if there is no metadata or if the metadata it is trying to load is invalid.

In these instances we send the error to sentry and force the server to fail.