### PR TITLE
Support content components in the necessary pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jwt'
 #     branch: 'submissions-v2'
 #gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
-gem 'metadata_presenter', '0.19.2'
+gem 'metadata_presenter', '0.21.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.0)
-    metadata_presenter (0.19.2)
+    metadata_presenter (0.21.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -288,7 +288,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.6.0)
   jwt
   listen (~> 3.5)
-  metadata_presenter (= 0.19.2)
+  metadata_presenter (= 0.21.0)
   prometheus-client (~> 2.1.0)
   puma (~> 5.2)
   rails (~> 6.1.3)

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -48,11 +48,12 @@ module Platform
 
     def pages
       service.pages.map do |page|
-        next if page.components.blank?
+        components = strip_content_components(page.components)
+        next if components.empty?
 
         {
           heading: heading(page),
-          answers: page.components.map do |component|
+          answers: components.map do |component|
             {
               field_id: component.id,
               field_name: component.humanised_title,
@@ -80,6 +81,13 @@ module Platform
 
     def heading(page)
       page.type == 'page.multiplequestions' ? page.heading : ''
+    end
+
+    private
+
+    def strip_content_components(components)
+      return [] if components.blank?
+      components.reject(&:content?)
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -3,6 +3,14 @@ RSpec.describe Platform::SubmitterPayload do
     described_class.new(service: service, user_data: user_data)
   end
 
+  def content_components
+    service.pages.map(&:components).compact.flatten.select(&:content?)
+  end
+
+  def content_components_text
+    content_components.map(&:html)
+  end
+
   let(:user_data) do
     {
       'name_text_1' => 'Legolas',
@@ -200,6 +208,14 @@ RSpec.describe Platform::SubmitterPayload do
             }
           )
       end
+    end
+
+    it 'does not send any content components text in the payload' do
+      answers = submitter_payload.to_h[:pages].map do |page_answers|
+        page_answers[:answers].map { |answers| answers[:answer] }
+      end.flatten
+
+      expect(answers & content_components_text).to be_empty
     end
   end
 end


### PR DESCRIPTION
Use version 0.21.0 of the presenter in order to suppor the presentation
of content components in the pages that require them.

We do not want content components to have anything sent to the submitter
as they are informational only and therefore no user answers are
collected.