### PR TITLE
Validate metadata pages on startup

### DIFF
--- a/app/services/load_service_metadata.rb
+++ b/app/services/load_service_metadata.rb
@@ -29,6 +29,9 @@ class LoadServiceMetadata
 
   def valid_metadata?
     MetadataPresenter::ValidateSchema.validate(metadata_to_load, 'service.base')
+    Array(metadata_to_load['pages']).each do |page|
+      MetadataPresenter::ValidateSchema.validate(page, page['_type'])
+    end
   end
 
   def error_message


### PR DESCRIPTION
Currently the single validation of the base level schema is not working correctly. The pages themselves need to be validate in the short term until the schema referencing is flattened a little.