### PR TITLE
Session duration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :require_basic_auth
+  before_action VerifySession
 
   EXCEPTIONS = [
     Platform::TimeoutError,

--- a/app/controllers/robots_txts_controller.rb
+++ b/app/controllers/robots_txts_controller.rb
@@ -1,5 +1,5 @@
 class RobotsTxtsController < ApplicationController
-  skip_before_action :require_basic_auth
+  skip_before_action :require_basic_auth, VerifySession
 
   def show
     if deny_all_crawlers?

--- a/app/filters/verify_session.rb
+++ b/app/filters/verify_session.rb
@@ -1,0 +1,19 @@
+class VerifySession
+  def self.before(controller)
+    if !allowed_pages?(controller) && controller.session[:session_id].blank?
+      controller.reset_session
+      controller.redirect_to controller.root_path
+    end
+  end
+
+  def self.allowed_pages?(controller)
+    urls = controller.service.standalone_pages.map(&:url)
+
+    controller.request.path == controller.root_path ||
+      urls.include?(strip_url(controller.request.path))
+  end
+
+  def self.strip_url(url)
+    url.to_s.chomp('/').reverse.chomp('/').reverse
+  end
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+Rails.application.config.session_store :cookie_store,
+  expire_after: ENV.fetch('SESSION_DURATION', 30).to_i.minutes,
+  key: '_fb_runner_session'

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -1,6 +1,10 @@
 RSpec.feature 'Navigation' do
   let(:form) { VersionFixture.new }
 
+  before do
+    allow(VerifySession).to receive(:before).and_return(false)
+  end
+
   background do
     given_the_service_has_a_metadata
   end

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -1,6 +1,10 @@
 RSpec.feature 'Navigation' do
   let(:form) { VersionFixture.new }
 
+  before do
+    allow(VerifySession).to receive(:before).and_return(false)
+  end
+
   background do
     given_the_service_has_a_metadata
     when_I_visit_the_service

--- a/spec/requests/verify_session_spec.rb
+++ b/spec/requests/verify_session_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe 'verify session', type: :request do
+  context 'when session id exists' do
+    before do
+      allow_any_instance_of(
+        ActionDispatch::Request
+      ).to receive(:session).and_return(
+        { session_id: SecureRandom.hex(24) }
+      )
+    end
+
+    context 'when other page' do
+      before do
+        get '/name'
+      end
+
+      it 'does not redirect the user' do
+        expect(response).to_not redirect_to('/')
+      end
+    end
+  end
+
+  context 'when session id is blank' do
+    context 'when root path' do
+      before do
+        get '/'
+      end
+
+      it 'does not redirect the user' do
+        expect(response).to_not redirect_to('/')
+      end
+    end
+
+    context 'when standalone page' do
+      before do
+        get '/cookies'
+      end
+
+      it 'does not redirect the user' do
+        expect(response).to_not redirect_to('/')
+      end
+    end
+
+    context 'when other page' do
+      before do
+        get '/name'
+      end
+
+      it 'redirects the user' do
+        expect(response).to redirect_to('/')
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/fEWsbJK4/1423-session-duration-for-runner)

## Context

This adds the session expiration to the runner. The default is 30 minutes and in the Runner is already customizable via env var.

Rails does automagically for us the expiration, which leave us to check for the `session[:session_id]` to be present. If is blank, we redirect the user to the root page for now. 

🚀 