### PR TITLE
Use Node 14.16.1 LTS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM ruby:2.7.2-alpine3.12
 
 ARG UID=1001
 
-RUN apk add --update nodejs yarn build-base bash libcurl git tzdata go
+RUN apk add --update yarn build-base bash libcurl git tzdata go
+
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.16.1-r2 npm
 
 # For load testing
 # Configure Go and install Vegeta

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,8 @@ lint:
 spec:
 	docker-compose -f docker-compose.ci.yml run --rm runner-app-ci bundle exec rspec
 
+.PHONY: assets
+assets:
+	yarn install
+	bundle exec rails assets:precompile
+	./bin/webpack

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # README
 
+## Setup
+Ensure you are running on Node version 14.16.1:
+`nvm use 14.16.1`
+
 To run the project locally, execute the following steps:
-- Install Ruby dependencies `bundle install`
-- Install all dependencies `yarn install`
-- Bundle JavaScript assets `./bin/webpack`
+- Install Ruby dependencies: `bundle install`
+- Compile all assets and run webpack: `make assets`
 
 ## Start the Rails server
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fb_runner",
   "private": true,
+  "engines" : { "node" : "14.16.1" },
   "dependencies": {
     "@rails/ujs": "^6.1.3",
     "@rails/webpacker": "^5.2.1",


### PR DESCRIPTION
We have some descrepencies with node versions in our containers but also
when developing locally. The README says use version 10 but the
container is installing 12 . . .

Lock the Node version to 14.16.1 as that is the current LTS version
which will be end of life in 2023.

Update the dockerfiles to install the specific node version and also use
a .npmrc file to lock the node version to the one we want.