### PR TITLE
Fix yarn install by fixing a version of remote docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ jobs:
     docker: *ecr_image
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - add_ssh_keys: *ssh_keys
       - run: *base_environment_variables
       - run: *deploy_scripts


### PR DESCRIPTION
[Trello card](https://trello.com/c/EOkv0DVR/1430-test-sentry-alerts-in-editor-and-runner-in-live-environments)

## Context

Yarn install is not working in the build and deploys to live. Let's make work!