### PR TITLE
Send the service slug in the submission request body

### DIFF
--- a/app/services/platform/submitter_adapter.rb
+++ b/app/services/platform/submitter_adapter.rb
@@ -16,11 +16,14 @@ module Platform
     end
 
     def save
-      request(:post, V2_URL, encrypted_submission)
+      request(:post, V2_URL, request_body)
     end
 
-    def encrypted_submission
-      { encrypted_submission: data_encryption.encrypt(payload.to_json) }
+    def request_body
+      {
+        encrypted_submission: data_encryption.encrypt(payload.to_json),
+        service_slug: service_slug
+      }
     end
 
     def encryption_key

--- a/spec/services/platform/submitter_adapter_spec.rb
+++ b/spec/services/platform/submitter_adapter_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Platform::SubmitterAdapter do
       {
         encrypted_submission: DataEncryption.new(key: key).encrypt(
           JSON.generate(payload)
-        )
+        ),
+        service_slug: service_slug
       }
     end
     let(:key) do


### PR DESCRIPTION
[Trello card](https://trello.com/c/9CqrcRCv/1492-internal-bug-we-are-not-saving-the-service-in-our-submitter-app)

## Context

We are not sending the service slug to the submitter for v2 and this could be a problem or more difficult to identify
which service belongs to the submission.

Refer to https://github.com/ministryofjustice/fb-submitter/pull/513
