### PR TITLE
Allow footer to move dynamically with page content

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,17 +15,9 @@
  */
 
 html {
-  min-height: 100%;
-  position: relative;
+  background-color: #F3F2F1;
 }
 
 #main-content {
-  margin-bottom: 220px; /* approx height of footer - prevents visual overlap */
-  position: relative;
-}
-
-.fb-footer {
-  position: absolute;
-  width: 100%;
-  bottom: 0;
+  min-height: 55vh;
 }


### PR DESCRIPTION
We previously stuck the footer to the bottom of the page. While this
looked nice it did also create an issue for any user that would zoom
into the page a little too much.

Therefore, remove the CSS which makes the footer stick and instead allow
it to move dynamically based on the content of a page. We then make the
background html element the same colour as the footer for the times when
there is not very much content on the page.

Users should now be able to zoom in and the content won't be obscured
by the footer.