### PR TITLE
Fix golang dependency installation issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,14 @@ FROM ruby:2.7.2-alpine3.12
 
 ARG UID=1001
 
-RUN apk add --update yarn build-base bash libcurl git tzdata go
+RUN apk add --update yarn build-base bash libcurl git tzdata
 
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.16.1-r2 npm
 
 # For load testing
-# Configure Go and install Vegeta
-ENV GOROOT /usr/lib/go
-ENV GOPATH /go
-ENV PATH /go/bin:$PATH
-RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
+# Copy Go and install Vegeta
+COPY --from=golang:1.16-alpine /usr/local/go/ /usr/local/go/
+ENV PATH="/usr/local/go/bin:${PATH}"
 RUN go get -u github.com/tsenart/vegeta
 
 RUN addgroup -g ${UID} -S appgroup && \


### PR DESCRIPTION
We install golang onto the container in order to have easy access to
the Vegeta package for load testing. It was failing installation during
the build process because of a `undefined: tls.Dialer` error.

One solution is for us to remove golang entirely as we only use it for
load testing.

However it seems that copying over the golang binary from the 1.16
golang alpine image directly into our container seems to solve the
installation issue.