### PR TITLE
Send empty string if date answer is blank

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -68,7 +68,9 @@ module Platform
       page_answers = MetadataPresenter::PageAnswers.new(page, user_data)
       answer = page_answers.send(component.id)
 
-      if answer.is_a?(MetadataPresenter::DateField) && answer.present?
+      if answer.is_a?(MetadataPresenter::DateField)
+        return '' if answer.blank?
+
         # how can we reuse the presenter code? Module?
         I18n.l(
           Date.civil(answer.year.to_i, answer.month.to_i, answer.day.to_i),


### PR DESCRIPTION
Before this commit we were sending the Datefield object instead
of an empty string. This triggers the schema validation for the
submitter payload. Adding as blank string makes the runner
send the right payload to Submitter

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>