### PR TITLE
Feature/upload

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,11 +1,13 @@
 
 # Services in acceptance tests repo
-# SUBMITTER_URL=http://localhost:10003
 # DATASTORE_URL=http://localhost:10001
+# FILESTORE_URL=http://localhost:10002
+# SUBMITTER_URL=http://localhost:10003
 
 SERVICE_SLUG=slug
 SERVICE_FIXTURE=version
 SERVICE_EMAIL_OUTPUT=form-builder-developers@digital.justice.gov.uk
+SERVICE_SECRET="d521235aff73a57a31352717a14f8775"
 
 # Details from the fb-acceptance-tests-repo
 SUBMISSION_ENCRYPTION_KEY='52905141-4738-4cce-8bd6-633c970c'

--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,13 @@ gem 'faraday_middleware'
 gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'feature/upload-files'
+# gem 'metadata_presenter',
+#    github: 'ministryofjustice/fb-metadata-presenter',
+#    branch: 'feature/upload-files'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-# gem 'metadata_presenter', '1.0.8'
+gem 'metadata_presenter', '1.1.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 gem 'metadata_presenter',
-     github: 'ministryofjustice/fb-metadata-presenter',
-     branch: 'feature/upload-files'
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'feature/upload-files'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-#gem 'metadata_presenter', '1.0.8'
+# gem 'metadata_presenter', '1.0.8'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.3'

--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,13 @@ gem 'faraday_middleware'
 gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'submissions-v2'
+gem 'metadata_presenter',
+     github: 'ministryofjustice/fb-metadata-presenter',
+     branch: 'feature/upload-files'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-gem 'metadata_presenter', '1.0.8'
+#gem 'metadata_presenter', '1.0.8'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 26349c96ed39149fe4bd6394e9da4c0d9a5eff05
+  branch: feature/upload-files
+  specs:
+    metadata_presenter (1.0.8)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -112,7 +123,7 @@ GEM
     ffi (1.15.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk_design_system_formbuilder (2.5.0)
+    govuk_design_system_formbuilder (2.5.1)
       actionview (>= 6.0)
       activemodel (>= 6.0)
       activesupport (>= 6.0)
@@ -135,11 +146,6 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (1.0.8)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.1)
@@ -334,7 +340,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   jwt
   listen (~> 3.5)
-  metadata_presenter (= 1.0.8)
+  metadata_presenter!
   prometheus-client (~> 2.1.0)
   puma (~> 5.3)
   rails (~> 6.1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 26349c96ed39149fe4bd6394e9da4c0d9a5eff05
-  branch: feature/upload-files
-  specs:
-    metadata_presenter (1.0.8)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (>= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 6.0.3.4, < 6.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -146,6 +135,11 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
+    metadata_presenter (1.1.0)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (>= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 6.0.3.4, < 6.2.0)
     method_source (1.0.0)
     mini_mime (1.0.3)
     mini_portile2 (2.5.1)
@@ -340,7 +334,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   jwt
   listen (~> 3.5)
-  metadata_presenter!
+  metadata_presenter (= 1.1.0)
   prometheus-client (~> 2.1.0)
   puma (~> 5.3)
   rails (~> 6.1.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,7 @@ class ApplicationController < ActionController::Base
   def upload_file
     @page_answers.page.upload_components.each do |component|
       user_filestore_payload = Platform::UserFilestorePayload.new(
+        session,
         @page_answers.send(component.id)
       ).call
       Platform::UserFilestoreAdapter.new(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -36,9 +36,7 @@ class ApplicationController < ActionController::Base
         component: component
       ).upload
 
-      @page_answers.uploaded_files.push(
-        UploadedFile.new(file: file, component: component)
-      )
+      @page_answers.uploaded_files.push(file)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,8 @@ class ApplicationController < ActionController::Base
   def create_submission
     Platform::Submission.new(
       service: service,
-      user_data: load_user_data
+      user_data: load_user_data,
+      session: session
     ).save
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,18 @@ class ApplicationController < ActionController::Base
     UserData.new(session).load_data
   end
 
+  def upload_file
+    @page_answers.page.upload_components.each do |component|
+      user_filestore_payload = Platform::UserFilestorePayload.new(
+        @page_answers.send(component.id)
+      ).call
+      Platform::UserFilestoreAdapter.new(
+        session,
+        payload: user_filestore_payload
+      ).call
+    end
+  end
+
   def create_submission
     Platform::Submission.new(
       service: service,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,11 @@ class ApplicationController < ActionController::Base
   helper_method :service
 
   def save_user_data
-    UserData.new(session).save(answer_params)
+    UserData.new(session).save(user_data_params)
+  end
+
+  def user_data_params
+    UserDataParams.new(@page_answers).answers
   end
 
   def load_user_data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ class ApplicationController < ActionController::Base
     @page_answers.page.upload_components.each do |component|
       user_filestore_payload = Platform::UserFilestorePayload.new(
         session,
-        @page_answers.send(component.id)
+        file_details: @page_answers.send(component.id)
       ).call
       Platform::UserFilestoreAdapter.new(
         session,

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,14 +30,15 @@ class ApplicationController < ActionController::Base
 
   def upload_file
     @page_answers.page.upload_components.each do |component|
-      user_filestore_payload = Platform::UserFilestorePayload.new(
-        session,
-        file_details: @page_answers.send(component.id)
-      ).call
-      Platform::UserFilestoreAdapter.new(
-        session,
-        payload: user_filestore_payload
-      ).call
+      file = FileUploader.new(
+        session: session,
+        page_answers: @page_answers,
+        component: component
+      ).upload
+
+      @page_answers.uploaded_files.push(
+        UploadedFile.new(file: file, component: component)
+      )
     end
   end
 

--- a/app/models/file_uploader.rb
+++ b/app/models/file_uploader.rb
@@ -1,0 +1,30 @@
+class MissingFilestoreUrlError < StandardError
+end
+
+class FileUploader
+  include ActiveModel::Model
+  attr_accessor :session, :page_answers, :component
+
+  def upload
+    if ENV['FILESTORE_URL'].blank?
+      raise MissingFilestoreUrlError if Rails.env.production?
+
+      OfflineUploadAdapter.new.call
+    else
+      user_filestore_payload = Platform::UserFilestorePayload.new(
+        session,
+        file_details: file_details
+      ).call
+      Platform::UserFilestoreAdapter.new(
+        session,
+        payload: user_filestore_payload
+      ).call
+    end
+  end
+
+  private
+
+  def file_details
+    @page_answers.send(component.id)
+  end
+end

--- a/app/models/file_uploader.rb
+++ b/app/models/file_uploader.rb
@@ -1,20 +1,6 @@
 class MissingFilestoreUrlError < StandardError
 end
 
-class UploadedFile
-  include ActiveModel::Model
-  attr_accessor :file, :component
-
-  def ==(other)
-    file == other.file && component == other.component
-  end
-
-  # add tests
-  def error_name
-    file.error_name if file.respond_to? :error_name
-  end
-end
-
 class FileUploader
   include ActiveModel::Model
   attr_accessor :session, :page_answers, :component

--- a/app/models/file_uploader.rb
+++ b/app/models/file_uploader.rb
@@ -15,6 +15,7 @@ class FileUploader
         session,
         file_details: file_details
       ).call
+
       Platform::UserFilestoreAdapter.new(
         session,
         payload: user_filestore_payload

--- a/app/models/offline_upload_adapter.rb
+++ b/app/models/offline_upload_adapter.rb
@@ -1,0 +1,3 @@
+class OfflineUploadAdapter
+  def call; end
+end

--- a/app/models/offline_upload_adapter.rb
+++ b/app/models/offline_upload_adapter.rb
@@ -1,3 +1,5 @@
 class OfflineUploadAdapter
-  def call; end
+  def call
+    {}
+  end
 end

--- a/app/models/session_data_adapter.rb
+++ b/app/models/session_data_adapter.rb
@@ -8,7 +8,6 @@ class SessionDataAdapter
   def save(answers)
     if answers.present?
       session[:user_data] ||= {}
-      session[:user_token] ||= SecureRandom.hex(256)
 
       answers.each do |field, answer|
         session[:user_data][field] = answer

--- a/app/models/session_data_adapter.rb
+++ b/app/models/session_data_adapter.rb
@@ -8,6 +8,7 @@ class SessionDataAdapter
   def save(answers)
     if answers.present?
       session[:user_data] ||= {}
+      session[:user_token] ||= SecureRandom.hex(256)
 
       answers.each do |field, answer|
         session[:user_data][field] = answer

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -1,0 +1,12 @@
+class UploadedFile
+  include ActiveModel::Model
+  attr_accessor :file, :component
+
+  def ==(other)
+    file == other.file && component == other.component
+  end
+
+  def error_name
+    file.error_name if file.respond_to? :error_name
+  end
+end

--- a/app/models/user_data.rb
+++ b/app/models/user_data.rb
@@ -9,6 +9,8 @@ class UserData
   end
 
   def adapter
+    session[:user_token] ||= SecureRandom.hex(16)
+
     return @adapter.new(session) if @adapter.present?
 
     if ENV['DATASTORE_URL'].present?

--- a/app/models/user_data.rb
+++ b/app/models/user_data.rb
@@ -1,3 +1,6 @@
+class MissingDatastoreUrlError < StandardError
+end
+
 class UserData
   attr_reader :session
 
@@ -16,6 +19,8 @@ class UserData
     if ENV['DATASTORE_URL'].present?
       Platform::UserDatastoreAdapter.new(session)
     else
+      raise MissingDatastoreUrlError if Rails.env.production?
+
       SessionDataAdapter.new(session)
     end
   end

--- a/app/models/user_data_params.rb
+++ b/app/models/user_data_params.rb
@@ -1,0 +1,17 @@
+class UserDataParams
+  def initialize(page_answers)
+    @page_answers = page_answers
+    @answer_params = @page_answers.answers.to_h
+  end
+
+  def answers
+    if @page_answers.uploaded_files.present?
+      @page_answers.uploaded_files.map do |uploaded_file|
+        @answer_params[uploaded_file.component.id] =
+          @page_answers.send(uploaded_file.component.id).merge(uploaded_file.file)
+      end
+    end
+
+    @answer_params
+  end
+end

--- a/app/services/platform/client_error.rb
+++ b/app/services/platform/client_error.rb
@@ -1,3 +1,13 @@
 module Platform
-  class ClientError < StandardError; end
+  class ClientError < StandardError
+    def initialize(exception)
+      @exception = exception
+
+      super(exception)
+    end
+
+    def response
+      @exception.response
+    end
+  end
 end

--- a/app/services/platform/connection.rb
+++ b/app/services/platform/connection.rb
@@ -41,7 +41,7 @@ module Platform
     rescue Faraday::ResourceNotFound => e
       raise Platform::ResourceNotFound, error_message(e)
     rescue StandardError => e
-      raise Platform::ClientError, error_message(e)
+      raise Platform::ClientError, e
     end
 
     def error_message(exception)

--- a/app/services/platform/submission.rb
+++ b/app/services/platform/submission.rb
@@ -17,7 +17,15 @@ module Platform
     def save
       raise MissingSubmitterUrlError if ENV['SUBMITTER_URL'].blank? && Rails.env.production?
 
-      invalid? || Platform::SubmitterAdapter.new(service_slug: service.service_slug, payload: submitter_payload).save
+      invalid? || adapter.save
+    end
+
+    def adapter
+      Platform::SubmitterAdapter.new(
+        session: session,
+        service_slug: service.service_slug,
+        payload: submitter_payload
+      )
     end
 
     def submitter_payload

--- a/app/services/platform/submission.rb
+++ b/app/services/platform/submission.rb
@@ -4,7 +4,7 @@ module Platform
 
   class Submission
     include ActiveModel::Model
-    attr_accessor :service, :user_data
+    attr_accessor :service, :user_data, :session
 
     REQUIRED_ENV_VARS = %w[SERVICE_EMAIL_OUTPUT SUBMITTER_URL].freeze
 
@@ -23,7 +23,8 @@ module Platform
     def submitter_payload
       Platform::SubmitterPayload.new(
         service: service,
-        user_data: user_data
+        user_data: user_data,
+        session: session
       ).to_h
     end
   end

--- a/app/services/platform/submission.rb
+++ b/app/services/platform/submission.rb
@@ -1,4 +1,7 @@
 module Platform
+  class MissingSubmitterUrlError < StandardError
+  end
+
   class Submission
     include ActiveModel::Model
     attr_accessor :service, :user_data
@@ -12,6 +15,7 @@ module Platform
     end
 
     def save
+      raise MissingSubmitterUrlError if ENV['SUBMITTER_URL'].blank? && Rails.env.production?
       invalid? || Platform::SubmitterAdapter.new(service_slug: service.service_slug, payload: submitter_payload).save
     end
 

--- a/app/services/platform/submission.rb
+++ b/app/services/platform/submission.rb
@@ -16,6 +16,7 @@ module Platform
 
     def save
       raise MissingSubmitterUrlError if ENV['SUBMITTER_URL'].blank? && Rails.env.production?
+
       invalid? || Platform::SubmitterAdapter.new(service_slug: service.service_slug, payload: submitter_payload).save
     end
 

--- a/app/services/platform/submitter_adapter.rb
+++ b/app/services/platform/submitter_adapter.rb
@@ -1,7 +1,7 @@
 module Platform
   class SubmitterAdapter
     include Platform::Connection
-    attr_reader :payload, :root_url, :service_slug
+    attr_reader :payload, :session, :root_url, :service_slug
 
     SUBSCRIPTION = 'submitter.request'.freeze
     TIMEOUT = 15
@@ -9,10 +9,12 @@ module Platform
 
     def initialize(payload:,
                    service_slug:,
+                   session:,
                    root_url: ENV['SUBMITTER_URL'])
       @payload = payload
       @root_url = root_url
       @service_slug = service_slug
+      @session = session
     end
 
     def save
@@ -22,7 +24,8 @@ module Platform
     def request_body
       {
         encrypted_submission: data_encryption.encrypt(payload.to_json),
-        service_slug: service_slug
+        service_slug: service_slug,
+        encrypted_user_id_and_token: session[:session_id]
       }
     end
 

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -1,12 +1,13 @@
 module Platform
   class SubmitterPayload
-    attr_reader :service, :user_data
+    attr_reader :service, :user_data, :session
 
     EMAIL = 'email'.freeze
 
-    def initialize(service:, user_data:)
+    def initialize(service:, user_data:, session:)
       @service = service
       @user_data = user_data
+      @session = session
     end
 
     def to_h
@@ -14,7 +15,8 @@ module Platform
         meta: meta,
         service: service_info,
         actions: actions,
-        pages: pages
+        pages: pages,
+        attachments: attachments
       }
     end
 
@@ -89,12 +91,40 @@ module Platform
       page.type == 'page.multiplequestions' ? page.heading : ''
     end
 
+    def attachments
+      answered_upload_components.map do |component|
+        {
+          url: file_download_url(component['fingerprint']),
+          filename: component['original_filename'],
+          mimetype: component['type'] || component['content_type']
+        }
+      end
+    end
+
     private
 
     def strip_content_components(components)
       return [] if components.blank?
 
       components.reject(&:content?)
+    end
+
+    def answered_upload_components
+      upload_components.map { |component| user_data[component.id] }.compact
+    end
+
+    def upload_components
+      components = service.pages.map do |page|
+        page.components&.select(&:upload?)
+      end
+      components.flatten.compact
+    end
+
+    def file_download_url(fingerprint)
+      "#{ENV['FILESTORE_URL']}" \
+      "/service/#{ENV['SERVICE_SLUG']}" \
+      "/user/#{session[:session_id]}" \
+      "/#{fingerprint}"
     end
   end
 end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -78,6 +78,8 @@ module Platform
         )
       elsif component.type == 'checkboxes'
         answer.to_a
+      elsif component.upload?
+        answer['original_filename']
       else
         answer
       end

--- a/app/services/platform/user_datastore_adapter.rb
+++ b/app/services/platform/user_datastore_adapter.rb
@@ -38,7 +38,7 @@ module Platform
     end
 
     def encryption_key
-      session[:user_token] ||= SecureRandom.uuid.gsub('-', '')
+      session[:user_token]
     end
 
     def subject

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -1,4 +1,13 @@
 module Platform
+  class FilestoreError
+    include ActiveModel::Model
+    attr_accessor :status, :body
+
+    def error?
+      true
+    end
+  end
+
   class UserFilestoreAdapter
     include Platform::Connection
     attr_reader :session, :root_url, :service_slug, :payload
@@ -7,9 +16,8 @@ module Platform
 
     def initialize(
       session,
-      root_url: ENV['FILESTORE_URL'],
-      service_slug: ENV['SERVICE_SLUG'],
-      payload:
+      payload:, root_url: ENV['FILESTORE_URL'],
+      service_slug: ENV['SERVICE_SLUG']
     )
       @session = session
       @root_url = root_url
@@ -21,18 +29,13 @@ module Platform
       return if root_url.blank?
 
       url = "/service/#{service_slug}/user/#{subject}"
-      request(:post, url, payload)
+      response = request(:post, url, payload)
+    rescue Platform::ClientError => e
+      response = e.response
 
-      # use the subject as the same as user_id which is on the url
-      # /service/:service_slug/user/:subject
-      # response = upload_to_file_store_using_same_user_id_from_session
-      #
-
-      # this will be used when sending the submission
-      # save_filestore_response_to_user_datastore(response)
-
-#      http://localhost:3000
-#      /service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1?payload=#{query_string_payload}
+      FilestoreError.new(
+        status: response[:status], body: JSON.parse(response[:body])
+      )
     end
 
     def subject

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -16,7 +16,8 @@ module Platform
 
     def initialize(
       session,
-      payload:, root_url: ENV['FILESTORE_URL'],
+      payload:,
+      root_url: ENV['FILESTORE_URL'],
       service_slug: ENV['SERVICE_SLUG']
     )
       @session = session

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -1,7 +1,7 @@
 module Platform
   class FilestoreError
     include ActiveModel::Model
-    attr_accessor :status, :body
+    attr_accessor :status, :error_name
 
     def error?
       true
@@ -30,12 +30,13 @@ module Platform
       return if root_url.blank?
 
       url = "/service/#{service_slug}/user/#{subject}"
-      request(:post, url, payload)
+      request(:post, url, payload).body
     rescue Platform::ClientError => e
       response = e.response
+      response_body = JSON.parse(response[:body], symbolize_names: true)
 
       FilestoreError.new(
-        status: response[:status], body: JSON.parse(response[:body])
+        status: response[:status], error_name: response_body[:name]
       )
     end
 

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -3,6 +3,8 @@ module Platform
     include Platform::Connection
     attr_reader :session, :root_url, :service_slug, :payload
 
+    SUBSCRIPTION = 'filestore.upload'.freeze
+
     def initialize(
       session,
       root_url: ENV['FILESTORE_URL'],
@@ -18,15 +20,31 @@ module Platform
     def call
       return if root_url.blank?
 
+      url = "/service/#{service_slug}/user/#{subject}"
+      request(:post, url, payload)
+
       # use the subject as the same as user_id which is on the url
       # /service/:service_slug/user/:subject
       # response = upload_to_file_store_using_same_user_id_from_session
+      #
 
       # this will be used when sending the submission
       # save_filestore_response_to_user_datastore(response)
 
 #      http://localhost:3000
 #      /service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1?payload=#{query_string_payload}
+    end
+
+    def subject
+      session[:session_id]
+    end
+
+    def subscription
+      SUBSCRIPTION
+    end
+
+    def timeout
+      10
     end
   end
 end

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -29,7 +29,7 @@ module Platform
       return if root_url.blank?
 
       url = "/service/#{service_slug}/user/#{subject}"
-      response = request(:post, url, payload)
+      request(:post, url, payload)
     rescue Platform::ClientError => e
       response = e.response
 

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -1,13 +1,32 @@
 module Platform
   class UserFilestoreAdapter
-    def initialize(session, root_url: ENV['FILESTORE_URL'], service_slug: ENV['SERVICE_SLUG'], payload:)
+    include Platform::Connection
+    attr_reader :session, :root_url, :service_slug, :payload
+
+    def initialize(
+      session,
+      root_url: ENV['FILESTORE_URL'],
+      service_slug: ENV['SERVICE_SLUG'],
+      payload:
+    )
       @session = session
       @root_url = root_url
       @service_slug = service_slug
       @payload = payload
     end
 
-    def upload(params)
+    def call
+      return if root_url.blank?
+
+      # use the subject as the same as user_id which is on the url
+      # /service/:service_slug/user/:subject
+      # response = upload_to_file_store_using_same_user_id_from_session
+
+      # this will be used when sending the submission
+      # save_filestore_response_to_user_datastore(response)
+
+#      http://localhost:3000
+#      /service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1?payload=#{query_string_payload}
     end
   end
 end

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -1,0 +1,13 @@
+module Platform
+  class UserFilestoreAdapter
+    def initialize(session, root_url: ENV['FILESTORE_URL'], service_slug: ENV['SERVICE_SLUG'], payload:)
+      @session = session
+      @root_url = root_url
+      @service_slug = service_slug
+      @payload = payload
+    end
+
+    def upload(params)
+    end
+  end
+end

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -2,7 +2,7 @@ module Platform
   class UserFilestorePayload
     attr_reader :session, :file_details, :service_secret
 
-    DEFAULT_EXPIRATION = 28.freeze
+    DEFAULT_EXPIRATION = 28
     ALLOWED_TYPES = %w[
       text/plain
       application/vnd.openxmlformats-officedocument.wordprocessingml.document
@@ -13,7 +13,7 @@ module Platform
       image/png
       application/vnd.ms-excel
     ].freeze
-    MAX_FILE_SIZE = 7340032.freeze
+    MAX_FILE_SIZE = 7_340_032
 
     def initialize(session, file_details:, service_secret: ENV['SERVICE_SECRET'])
       @session = session
@@ -27,8 +27,8 @@ module Platform
         'file': encoded_file,
         'policy': {
           'allowed_types': allowed_types,
-            'max_size': MAX_FILE_SIZE,
-            'expires': expires
+          'max_size': MAX_FILE_SIZE,
+          'expires': expires
         }
       }
     end

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -23,12 +23,12 @@ module Platform
 
     def call
       {
-        "encrypted_user_id_and_token": encrypted_user_id_and_token,
-        "file": encoded_file,
-        "policy": {
-          "allowed_types": allowed_types,
-            "max_size": MAX_FILE_SIZE,
-            "expires": expires
+        'encrypted_user_id_and_token': encrypted_user_id_and_token,
+        'file': encoded_file,
+        'policy': {
+          'allowed_types': allowed_types,
+            'max_size': MAX_FILE_SIZE,
+            'expires': expires
         }
       }
     end
@@ -50,7 +50,15 @@ module Platform
     end
 
     def encrypted_user_id_and_token
-      DataEncryption.new(key: service_secret).encrypt("#{session[:session_id]}#{session[:user_token]}")
+      DataEncryption.new(
+        key: service_secret
+      ).encrypt("#{user_id}#{session[:user_token]}")
+    end
+
+    private
+
+    def user_id
+      session[:session_id]
     end
 
     # payload = json_request(Base64.strict_encode64(File.open(Rails.root.join('spec/fixtures/files/image.png')).read));

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -60,20 +60,5 @@ module Platform
     def user_id
       session[:session_id]
     end
-
-    # payload = json_request(Base64.strict_encode64(File.open(Rails.root.join('spec/fixtures/files/image.png')).read));
-    # jwt_payload = { iat: Time.now.to_i, checksum: Digest::SHA256.hexdigest(payload.to_json) }
-    # `curl -X POST --header "x-access-token: #{JWT.encode(jwt_payload, 'service-token', 'HS256')}" --header "Content-Type: application/JSON" --data '#{payload.to_json}' http://localhost:3000/service/some-service/user/some-user`
-
-    # response => "{\"url\":\"/service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1\",\"size\":173,\"type\":\"image/png\",\"date\":1554734786}"
-
-    # payload = { encrypted_user_id_and_token: '12345678901234567890123456789012', iat: Time.now.to_i }
-    # jwt_payload = { iat: Time.now.to_i, checksum: Digest::SHA256.hexdigest(payload.to_json) }
-    # query_string_payload = Base64.strict_encode64(payload.to_json)
-    # response = `curl -X GET --header "x-access-token: #{JWT.encode(jwt_payload, 'service-token', 'HS256')}" http://localhost:3000/service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1?payload=#{query_string_payload}`
-
-    # hash = JSON.parse(response)
-
-    # File.open('/tmp/out', 'wb') {|f| f.write Base64.strict_decode64(hash['file'])
   end
 end

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -1,6 +1,6 @@
 module Platform
   class UserFilestorePayload
-    attr_reader :file_details
+    attr_reader :session, :file_details, :service_secret
 
     DEFAULT_EXPIRATION = 28.freeze
     ALLOWED_TYPES = %w[
@@ -15,8 +15,10 @@ module Platform
     ].freeze
     MAX_FILE_SIZE = 7340032.freeze
 
-    def initialize(file_details)
+    def initialize(session, file_details:, service_secret: ENV['SERVICE_SECRET'])
+      @session = session
       @file_details = file_details
+      @service_secret = service_secret
     end
 
     def call
@@ -48,9 +50,8 @@ module Platform
     end
 
     def encrypted_user_id_and_token
-      # SHA-256 Hash of session.id + user_data[:user_token] + service_token
+      DataEncryption.new(key: service_secret).encrypt("#{session[:session_id]}#{session[:user_token]}")
     end
-
 
     # payload = json_request(Base64.strict_encode64(File.open(Rails.root.join('spec/fixtures/files/image.png')).read));
     # jwt_payload = { iat: Time.now.to_i, checksum: Digest::SHA256.hexdigest(payload.to_json) }

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -1,0 +1,32 @@
+module Platform
+  class UserFilestorePayload
+    def initialize
+    end
+
+
+
+
+
+
+
+
+
+
+
+
+    # payload = json_request(Base64.strict_encode64(File.open(Rails.root.join('spec/fixtures/files/image.png')).read));
+    # jwt_payload = { iat: Time.now.to_i, checksum: Digest::SHA256.hexdigest(payload.to_json) }
+    # `curl -X POST --header "x-access-token: #{JWT.encode(jwt_payload, 'service-token', 'HS256')}" --header "Content-Type: application/JSON" --data '#{payload.to_json}' http://localhost:3000/service/some-service/user/some-user`
+
+    # response => "{\"url\":\"/service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1\",\"size\":173,\"type\":\"image/png\",\"date\":1554734786}"
+
+    # payload = { encrypted_user_id_and_token: '12345678901234567890123456789012', iat: Time.now.to_i }
+    # jwt_payload = { iat: Time.now.to_i, checksum: Digest::SHA256.hexdigest(payload.to_json) }
+    # query_string_payload = Base64.strict_encode64(payload.to_json)
+    # response = `curl -X GET --header "x-access-token: #{JWT.encode(jwt_payload, 'service-token', 'HS256')}" http://localhost:3000/service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1?payload=#{query_string_payload}`
+
+    # hash = JSON.parse(response)
+
+    # File.open('/tmp/out', 'wb') {|f| f.write Base64.strict_decode64(hash['file'])
+  end
+end

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -1,17 +1,55 @@
 module Platform
   class UserFilestorePayload
-    def initialize
+    attr_reader :file_details
+
+    DEFAULT_EXPIRATION = 28.freeze
+    ALLOWED_TYPES = %w[
+      text/plain
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      application/msword
+      application/vnd.oasis.opendocument.text
+      application/pdf
+      image/jpeg
+      image/png
+      application/vnd.ms-excel
+    ].freeze
+    MAX_FILE_SIZE = 7340032.freeze
+
+    def initialize(file_details)
+      @file_details = file_details
     end
 
+    def call
+      {
+        "encrypted_user_id_and_token": encrypted_user_id_and_token,
+        "file": encoded_file,
+        "policy": {
+          "allowed_types": allowed_types,
+            "max_size": MAX_FILE_SIZE,
+            "expires": expires
+        }
+      }
+    end
 
+    def expires
+      DEFAULT_EXPIRATION
+    end
 
+    def allowed_types
+      ALLOWED_TYPES
+    end
 
+    def temp_file
+      File.open(file_details['tempfile']).read
+    end
 
+    def encoded_file
+      Base64.strict_encode64(temp_file)
+    end
 
-
-
-
-
+    def encrypted_user_id_and_token
+      # SHA-256 Hash of session.id + user_data[:user_token] + service_token
+    end
 
 
     # payload = json_request(Base64.strict_encode64(File.open(Rails.root.join('spec/fixtures/files/image.png')).read));

--- a/config/initializers/filestore_instrumentation.rb
+++ b/config/initializers/filestore_instrumentation.rb
@@ -1,0 +1,33 @@
+Rails.application.reloader.to_prepare do
+  ActiveSupport::Notifications.subscribe(
+    Platform::UserFilestoreAdapter::SUBSCRIPTION
+  ) do |name, starts, ends, _, env|
+    url = env[:url]
+    http_method = env[:method].to_s.upcase
+    duration = ends - starts
+    response_status = env[:status]
+
+    if Rails.env.production?
+      Rails.logger.info(
+        'Filestore API request: [%s] %s (%.3f s). Response status: %s' % [
+          url.host,
+          http_method,
+          duration,
+          response_status
+        ]
+      )
+    else
+      Rails.logger.info(
+        'Filestore API request: [%s] %s %s (%.3f s). Request Headers %s. Response Body: %s. Response status: %s' % [
+          url.host,
+          http_method,
+          env[:url].to_s,
+          duration,
+          env[:request_headers],
+          env[:response_body],
+          response_status
+        ]
+      )
+    end
+  end
+end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -134,6 +134,7 @@ RSpec.feature 'Navigation' do
   end
 
   def and_I_check_that_my_answers_are_correct
+    expect(page.current_url).to include('check-answers')
     expect(form.full_name_checkanswers.text).to include("Full name Han Solo")
     expect(form.email_checkanswers.text).to include(
       "Email address han.solo@gmail.com"

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_burger
     and_I_add_my_star_wars_knowledge
     and_I_visit_the_how_many_lights_page
+    and_I_upload_a_dog_picture
     and_I_check_that_my_answers_are_correct
     and_I_change_my_full_name_answer
     then_I_should_see_my_changed_full_name_on_check_your_answers
@@ -53,6 +54,7 @@ RSpec.feature 'Navigation' do
     and_I_add_my_burger
     and_I_add_my_star_wars_knowledge
     and_I_visit_the_how_many_lights_page
+    and_I_upload_a_dog_picture
     and_I_check_that_my_answers_are_correct
     and_I_send_my_application
     then_I_should_see_the_confirmation_message
@@ -156,6 +158,9 @@ RSpec.feature 'Navigation' do
     expect(form.star_wars_knowledge_2_checkanswers.text).to include(
       "What is The Mandalorian's real name? Din Jarrin Change Your answer for What is The Mandalorian's real name?"
     )
+    expect(form.dog_picture_checkanswers.text).to include(
+      'Upload your best dog photo thats-not-a-knife.txt'
+    )
   end
 
   def and_I_send_my_application
@@ -165,6 +170,15 @@ RSpec.feature 'Navigation' do
   def and_I_change_my_full_name_answer
     form.full_name_change_answer_link.click
     form.full_name_field.set('Jabba')
+    and_I_go_to_next_page
+  end
+
+  def and_I_upload_a_dog_picture
+    # it is not a dog picture but it is a file.
+    attach_file(
+      'answers[dog-picture_upload_1]',
+      'spec/fixtures/thats-not-a-knife.txt'
+    )
     and_I_go_to_next_page
   end
 

--- a/spec/features/validations_spec.rb
+++ b/spec/features/validations_spec.rb
@@ -73,6 +73,16 @@ RSpec.feature 'Navigation' do
     then_I_should_see_that_I_should_add_a_valid_holiday
   end
 
+  scenario 'when upload is required and there is no file' do
+    and_I_go_to_dog_picture_page
+    and_I_go_to_next_page
+    then_I_should_see_that_I_should_add_a_dog_picture
+  end
+
+  def and_I_go_to_dog_picture_page
+    visit '/dog-picture'
+  end
+
   def and_I_left_my_name_blank
     form.full_name_field.set('')
     and_I_go_to_next_page
@@ -180,6 +190,12 @@ RSpec.feature 'Navigation' do
   def then_I_should_see_choose_a_checkbox
     then_I_should_see_the_error_message(
       'Enter an answer for What would you like on your burger?'
+    )
+  end
+
+  def then_I_should_see_that_I_should_add_a_dog_picture
+    then_I_should_see_the_error_message(
+      'Enter an answer for Upload your best dog photo'
     )
   end
 

--- a/spec/fixtures/thats-not-a-knife.txt
+++ b/spec/fixtures/thats-not-a-knife.txt
@@ -1,0 +1,1 @@
+THIS IS A KNIFE!

--- a/spec/models/file_uploader_spec.rb
+++ b/spec/models/file_uploader_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe FileUploader do
+  subject(:file_uploader) do
+    described_class.new(
+      session: session,
+      page_answers: page_answers,
+      component: component
+    )
+  end
+  let(:session) { { session_id: '3337407fcd59870be6f15daccf17d311' } }
+  let(:page_answers) do
+    double(
+      'dog-picture' => {
+        'original_filename' => './spec/fixtures/thats-not-a-knife.txt',
+        'content_type' => 'text/plain',
+        'tempfile' => Rails.root.join('spec', 'fixtures', 'thats-not-a-knife.txt')
+      }
+    )
+  end
+  let(:component) { double(id: 'dog-picture') }
+
+  before do
+    allow(ENV).to receive(:[])
+    allow(ENV).to receive(:[]).with('SERVICE_SECRET').and_return(
+      '36a1740b-9d26-4185-a302-5c2ea9b5'
+    )
+  end
+
+  describe '#upload' do
+    context 'when filestore is enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('FILESTORE_URL').and_return(
+          'http://filestore-svc/'
+        )
+      end
+
+      it 'calls filestore adapter' do
+        expect_any_instance_of(Platform::UserFilestoreAdapter).to receive(
+          :call
+        )
+
+        file_uploader.upload
+      end
+    end
+
+    context 'when filestore is not enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('FILESTORE_URL').and_return(nil)
+      end
+
+      context 'when production environment' do
+        before do
+          allow(Rails.env).to receive(:production?).and_return(true)
+        end
+
+        it 'raises exception' do
+          expect {
+            file_uploader.upload
+          }.to raise_error(MissingFilestoreUrlError)
+        end
+      end
+
+      context 'when not in live environment' do
+        before do
+          allow(Rails.env).to receive(:production?).and_return(false)
+        end
+
+        it 'call offline upload adapter' do
+          expect_any_instance_of(OfflineUploadAdapter).to receive(:call)
+          file_uploader.upload
+        end
+      end
+    end
+  end
+end

--- a/spec/models/file_uploader_spec.rb
+++ b/spec/models/file_uploader_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe FileUploader do
       let(:filestore_response) do
         {
           'fingerprint' => '28d-3ed12ce99192845d1da98c32797d7c815280db922e006554991332cf2a2dd832',
-          'size' => 191317,
+          'size' => 191_317,
           'type' => 'image/png',
-          'date' => 1623933256
+          'date' => 1_623_933_256
         }
       end
 

--- a/spec/models/file_uploader_spec.rb
+++ b/spec/models/file_uploader_spec.rb
@@ -27,6 +27,15 @@ RSpec.describe FileUploader do
 
   describe '#upload' do
     context 'when filestore is enabled' do
+      let(:filestore_response) do
+        {
+          'fingerprint' => '28d-3ed12ce99192845d1da98c32797d7c815280db922e006554991332cf2a2dd832',
+          'size' => 191317,
+          'type' => 'image/png',
+          'date' => 1623933256
+        }
+      end
+
       before do
         allow(ENV).to receive(:[]).with('FILESTORE_URL').and_return(
           'http://filestore-svc/'
@@ -36,9 +45,12 @@ RSpec.describe FileUploader do
       it 'calls filestore adapter' do
         expect_any_instance_of(Platform::UserFilestoreAdapter).to receive(
           :call
+        ).and_return(
+          filestore_response
         )
-
-        file_uploader.upload
+        expect(file_uploader.upload).to eq(
+          UploadedFile.new(file: filestore_response, component: component)
+        )
       end
     end
 

--- a/spec/models/offline_upload_adapter_spec.rb
+++ b/spec/models/offline_upload_adapter_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe OfflineUploadAdapter do
+  describe '#call' do
+    it 'returns an empty hash' do
+      expect(subject.call).to eq({})
+    end
+  end
+end

--- a/spec/models/uploaded_file_spec.rb
+++ b/spec/models/uploaded_file_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe UploadedFile do
+  subject(:uploaded_file) do
+    described_class.new(
+      file: file,
+      component: component
+    )
+  end
+  let(:file) { double }
+  let(:component) { double }
+
+  describe '#error_name' do
+    context 'when object has errors' do
+      let(:file) { double(error_name: 'invalid.virus') }
+
+      it 'returns error name' do
+        expect(uploaded_file.error_name).to eq('invalid.virus')
+      end
+    end
+
+    context 'when object is uploaded' do
+      it 'returns nil' do
+        expect(uploaded_file.error_name).to be_nil
+      end
+    end
+  end
+end

--- a/spec/models/user_data_params_spec.rb
+++ b/spec/models/user_data_params_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UserDataParams do
         {
           'fingerprint' => '28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
           'size' => 1_392_565,
-          'type' => 'image/png',
+          'type' => 'plain/txt',
           'date' => 1_624_540_833
         }
       end

--- a/spec/models/user_data_params_spec.rb
+++ b/spec/models/user_data_params_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe UserDataParams do
+  subject(:user_data_params) do
+    described_class.new(page_answers)
+  end
+  let(:page_answers) do
+    MetadataPresenter::PageAnswers.new(page, answers)
+  end
+
+  describe '#answers' do
+    context 'when page has uploaded files' do
+      let(:page) { service.find_page_by_url('dog-picture') }
+      let(:file_details) do
+        Rack::Test::UploadedFile.new(
+          './spec/fixtures/thats-not-a-knife.txt',
+          'plain/txt'
+        )
+      end
+      let(:answers) do
+        {
+          'dog-picture_upload_1' => file_details
+        }
+      end
+      let(:file) do
+        {
+          'fingerprint' => '28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
+          'size' => 1_392_565,
+          'type' => 'image/png',
+          'date' => 1_624_540_833
+        }
+      end
+      let(:uploaded_files) do
+        [
+          UploadedFile.new(file: file, component: page.components.first)
+        ]
+      end
+
+      before do
+        allow(page_answers).to receive(:uploaded_files).and_return(uploaded_files)
+      end
+
+      it 'returns the file information' do
+        expect(user_data_params.answers).to eq(
+          {
+            'dog-picture_upload_1' => {
+              'original_filename' => 'thats-not-a-knife.txt',
+              'content_type' => 'plain/txt',
+              'tempfile' => file_details.tempfile.path.to_s
+            }.merge(file)
+          }
+        )
+      end
+    end
+
+    context 'when other answers' do
+      let(:page) { service.find_page_by_url('name') }
+      let(:answers) { { 'name_text_1' => 'John Wick' } }
+
+      it 'returns the answers' do
+        expect(user_data_params.answers).to eq(answers)
+      end
+    end
+  end
+end

--- a/spec/models/user_data_spec.rb
+++ b/spec/models/user_data_spec.rb
@@ -53,10 +53,25 @@ RSpec.describe UserData do
 
       before do
         allow(ENV).to receive(:[]).with('DATASTORE_URL').and_return('')
+        allow(Rails.env).to receive(:production?).and_return(production?)
       end
 
-      it 'returns the session adapter' do
-        expect(user_data.adapter).to be_instance_of(SessionDataAdapter)
+      context 'when is production' do
+        let(:production?) { true }
+
+        it 'raises an error' do
+          expect {
+            user_data.adapter
+          }.to raise_error(MissingDatastoreUrlError)
+        end
+      end
+
+      context 'when is not production' do
+        let(:production?) { false }
+
+        it 'returns the session adapter' do
+          expect(user_data.adapter).to be_instance_of(SessionDataAdapter)
+        end
       end
     end
   end

--- a/spec/models/user_data_spec.rb
+++ b/spec/models/user_data_spec.rb
@@ -39,6 +39,13 @@ RSpec.describe UserData do
           Platform::UserDatastoreAdapter
         )
       end
+
+      it 'sets user token before calling the adapter' do
+        allow(SecureRandom).to receive(:hex)
+          .and_return('975e146ab6fe0a2e25fe224f404d11e6')
+        user_data.adapter
+        expect(session[:user_token]).to eq('975e146ab6fe0a2e25fe224f404d11e6')
+      end
     end
 
     context 'when no adapter is passed and there is no datastore url' do

--- a/spec/services/platform/submission_spec.rb
+++ b/spec/services/platform/submission_spec.rb
@@ -33,9 +33,27 @@ RSpec.describe Platform::Submission do
     context 'when invalid' do
       let(:invalid) { true }
 
-      it 'does not send the submission' do
-        expect_any_instance_of(Platform::SubmitterAdapter).to_not receive(:save)
-        submission.save
+      before do
+        allow(Rails.env).to receive(:production?).and_return(production?)
+      end
+
+      context 'when env is production' do
+        let(:production?) { true }
+
+        it 'raises an error' do
+          expect {
+            submission.save
+          }.to raise_error(Platform::MissingSubmitterUrlError)
+        end
+      end
+
+      context 'when env is not production' do
+        let(:production?) { false }
+
+        it 'does not send the submission' do
+          expect_any_instance_of(Platform::SubmitterAdapter).to_not receive(:save)
+          submission.save
+        end
       end
     end
   end

--- a/spec/services/platform/submission_spec.rb
+++ b/spec/services/platform/submission_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe Platform::Submission do
   subject(:submission) do
-    described_class.new(service: service, user_data: user_data)
+    described_class.new(service: service, user_data: user_data, session: session)
   end
   let(:user_data) { {} }
+  let(:session) { {} }
 
   describe '#save' do
     before do
@@ -23,7 +24,7 @@ RSpec.describe Platform::Submission do
 
       it 'sends the submission' do
         expect(Platform::SubmitterAdapter).to receive(:new)
-          .with(payload: payload, service_slug: service.service_slug)
+          .with(session: session, payload: payload, service_slug: service.service_slug)
           .and_return(adapter)
         expect(adapter).to receive(:save)
         submission.save

--- a/spec/services/platform/submitter_adapter_spec.rb
+++ b/spec/services/platform/submitter_adapter_spec.rb
@@ -3,13 +3,15 @@ RSpec.describe Platform::SubmitterAdapter do
     described_class.new(
       payload: payload,
       root_url: root_url,
-      service_slug: service_slug
+      service_slug: service_slug,
+      session: session
     )
   end
   let(:root_url) do
     'http://submitter.com'
   end
   let(:service_slug) { 'lotr' }
+  let(:session) { { session_id: 'fa018e7bef6460c2a52818bab9731304' } }
 
   describe '#save' do
     let(:payload) do
@@ -33,7 +35,8 @@ RSpec.describe Platform::SubmitterAdapter do
         encrypted_submission: DataEncryption.new(key: key).encrypt(
           JSON.generate(payload)
         ),
-        service_slug: service_slug
+        service_slug: service_slug,
+        encrypted_user_id_and_token: 'fa018e7bef6460c2a52818bab9731304'
       }
     end
     let(:key) do

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -142,6 +142,16 @@ RSpec.describe Platform::SubmitterPayload do
             answer: 'Din Jarrin'
           }
         ]
+      },
+      {
+        heading: '',
+        answers: [
+          {
+            answer: {}, # this should be the name of the file
+            field_id: 'dog-picture_upload_1',
+            field_name: 'Upload your best dog photo'
+          }
+        ]
       }
     ]
   end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -24,8 +24,18 @@ RSpec.describe Platform::SubmitterPayload do
       'holiday_date_1(1i)' => '2020',
       'burgers_checkboxes_1' => ['Beef, cheese, tomato', 'Chicken, cheese, tomato'],
       'star-wars-knowledge_text_1' => 'Max Rebo Band',
-      'star-wars-knowledge_radios_1' => 'Din Jarrin'
+      'star-wars-knowledge_radios_1' => 'Din Jarrin',
+      'dog-picture_upload_1' => {
+        'original_filename' => 'basset-hound.jpg',
+        'content_type' => 'image/jpg',
+        'tempfile' => upload_file.path
+      }
     }
+  end
+  let(:upload_file) do
+    Rack::Test::UploadedFile.new(
+      './spec/fixtures/basset-hound.jpg', 'image/jpg'
+    )
   end
   let(:pdf_heading) do
     'Middle Earth characters'
@@ -147,7 +157,7 @@ RSpec.describe Platform::SubmitterPayload do
         heading: '',
         answers: [
           {
-            answer: {}, # this should be the name of the file
+            answer: 'basset-hound.jpg',
             field_id: 'dog-picture_upload_1',
             field_name: 'Upload your best dog photo'
           }

--- a/spec/services/platform/user_filestore_adapter_spec.rb
+++ b/spec/services/platform/user_filestore_adapter_spec.rb
@@ -1,0 +1,102 @@
+RSpec.describe Platform::UserFilestoreAdapter do
+  subject(:adapter) do
+    described_class.new(
+      session,
+      root_url: root_url,
+      service_slug: service_slug,
+      payload: payload
+    )
+  end
+  let(:session) { double(id: 'some-id') }
+  let(:root_url) { 'http://filestore-svc' }
+  let(:service_slug) { 'juggling-license' }
+  let(:payload) { {} }
+
+  describe '#call' do
+    context 'when there is filestore url' do
+      let(:expected_url) do
+        "#{root_url}/service/#{service_slug}/user/#{session.id}"
+      end
+      let(:expected_payload) do
+        {
+          "encrypted_user_id_and_token": '12345678901234567890123456789012',
+          "file": encoded_file,
+          "policy": {
+            "allowed_types": allowed_types,
+              "max_size": MAX_FILE_SIZE,
+              "expires": expires
+          }
+        }
+      end
+      let(:expected_headers) do
+        {
+          'Content-Type': 'application/JSON',
+          'x-access-token': {
+
+          }
+        }
+      end
+      let(:response_body) do
+        {
+          "url": "/service/{service_slug}/{user_id}/{fingerprint}",
+          "size": "<integer>(bytes)",
+          "type": "<string>(mediatype)",
+          "date": "<integer>(unix_timestamp)"
+        }
+
+        "{\"url\":\"/service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1\",\"size\":173,\"type\":\"image/png\",\"date\":1554734786}"
+      end
+
+      before do
+        stub_request(:post, expected_url)
+          .with(body: expected_payload, headers: expected_headers)
+          .to_return(status: 201, body: response_body, headers: {})
+      end
+
+      it 'makes a request to filestore' do
+        adapter.call
+        expect(WebMock).to have_requested(
+          :post, expected_url
+        ).with(headers: expected_headers, body: expected_payload)
+         .once
+      end
+    end
+
+    context 'when there is not filestore url' do
+      it 'returns nil' do
+        expect(adapter.call).to be_nil
+      end
+    end
+
+    context 'when there is no encrypted user id and token in the payload' do
+      # Error if encrypted_user_id_and_token property is not present
+      # code: 403
+      # name: forbidden.user-id-token-missing
+    end
+
+    context 'when the file is too large' do
+      # Perform size check if policy.max_size is present
+      # Error if file is too large
+      # code: 400
+      # name: invalid.too-large
+      # max_size: {max_size}
+      # size: {file_size}
+    end
+
+    context 'when the file type is not allowed' do
+      # Perform file type checks if policy.allowed_types is present
+      # Error if file is wrong type
+      # code: 400
+      # name: invalid.type
+      # type: {file_type}
+    end
+
+    context 'when there is a virus' do
+      # Send to virus scanning service
+      # Error if file contains virus
+      # code: 400
+      # name: invalid.virus
+      # virus_name: {virus_name}
+    end
+  end
+end

--- a/spec/services/platform/user_filestore_adapter_spec.rb
+++ b/spec/services/platform/user_filestore_adapter_spec.rb
@@ -115,9 +115,7 @@ RSpec.describe Platform::UserFilestoreAdapter do
       end
 
       it 'assigns the response body' do
-        expect(adapter.call.body).to eq(
-          { 'code' => 400, 'name' => 'invalid.virus' }
-        )
+        expect(adapter.call.error_name).to eq('invalid.virus')
       end
     end
   end

--- a/spec/services/platform/user_filestore_adapter_spec.rb
+++ b/spec/services/platform/user_filestore_adapter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Platform::UserFilestoreAdapter do
   end
 
   describe '#call' do
-    RSpec.shared_context "filestore_error_response" do
+    RSpec.shared_context 'filestore_error_response' do
       it 'returns an error response' do
         expect(adapter.call.error?).to be_truthy
       end
@@ -136,7 +136,7 @@ RSpec.describe Platform::UserFilestoreAdapter do
           })
         end
         let(:response_status) { 400 }
-        let(:error_name) {'invalid.virus'}
+        let(:error_name) { 'invalid.virus' }
       end
     end
   end

--- a/spec/services/platform/user_filestore_adapter_spec.rb
+++ b/spec/services/platform/user_filestore_adapter_spec.rb
@@ -49,14 +49,12 @@ RSpec.describe Platform::UserFilestoreAdapter do
   describe '#call' do
     context 'when there is filestore url' do
       let(:response_body) do
-        {
+        JSON.generate({
           'url': '/service/{service_slug}/{user_id}/{fingerprint}',
           'size': '<integer>(bytes)',
           'type': '<string>(mediatype)',
           'date': '<integer>(unix_timestamp)'
-        }
-
-        '{"url":"/service/some-service/user/some-user/28d-e71c352d0852ab802592a02168877dc255d9c839a7537d91efed04a5865549c1","size":173,"type":"image/png","date":1554734786}'
+        })
       end
 
       it 'makes a request to filestore' do

--- a/spec/services/platform/user_filestore_adapter_spec.rb
+++ b/spec/services/platform/user_filestore_adapter_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe Platform::UserFilestoreAdapter do
   end
 
   describe '#call' do
+    RSpec.shared_context "filestore_error_response" do
+      it 'returns an error response' do
+        expect(adapter.call.error?).to be_truthy
+      end
+
+      it 'assigns the status' do
+        expect(adapter.call.status).to be(response_status)
+      end
+
+      it 'assigns the response body' do
+        expect(adapter.call.error_name).to eq(error_name)
+      end
+    end
+
     context 'when there is filestore url' do
       let(:response_body) do
         JSON.generate({
@@ -74,48 +88,55 @@ RSpec.describe Platform::UserFilestoreAdapter do
       end
     end
 
-    context 'when there is no encrypted user id and token in the payload' do
-      # Error if encrypted_user_id_and_token property is not present
-      # code: 403
-      # name: forbidden.user-id-token-missing
+    context 'when there is no encrypted_user_id_and_token in the payload' do
+      include_context 'filestore_error_response' do
+        let(:response_body) do
+          JSON.generate({
+            code: 403,
+            name: 'forbidden.user-id-token-missing'
+          })
+        end
+        let(:response_status) { 403 }
+        let(:error_name) { 'forbidden.user-id-token-missing' }
+      end
     end
 
     context 'when the file is too large' do
-      # Perform size check if policy.max_size is present
-      # Error if file is too large
-      # code: 400
-      # name: invalid.too-large
-      # max_size: {max_size}
-      # size: {file_size}
+      include_context 'filestore_error_response' do
+        let(:response_body) do
+          JSON.generate({
+            code: 400,
+            name: 'invalid.too-large'
+          })
+        end
+        let(:response_status) { 400 }
+        let(:error_name) { 'invalid.too-large' }
+      end
     end
 
     context 'when the file type is not allowed' do
-      # Perform file type checks if policy.allowed_types is present
-      # Error if file is wrong type
-      # code: 400
-      # name: invalid.type
-      # type: {file_type}
+      include_context 'filestore_error_response' do
+        let(:response_body) do
+          JSON.generate({
+            code: 400,
+            name: 'invalid.type'
+          })
+        end
+        let(:response_status) { 400 }
+        let(:error_name) { 'invalid.type' }
+      end
     end
 
     context 'when there is a virus' do
-      let(:response_body) do
-        JSON.generate({
-          code: 400,
-          name: 'invalid.virus'
-        })
-      end
-      let(:response_status) { 400 }
-
-      it 'returns an error response' do
-        expect(adapter.call.error?).to be_truthy
-      end
-
-      it 'assigns the status' do
-        expect(adapter.call.status).to be(400)
-      end
-
-      it 'assigns the response body' do
-        expect(adapter.call.error_name).to eq('invalid.virus')
+      include_context 'filestore_error_response' do
+        let(:response_body) do
+          JSON.generate({
+            code: 400,
+            name: 'invalid.virus'
+          })
+        end
+        let(:response_status) { 400 }
+        let(:error_name) {'invalid.virus'}
       end
     end
   end

--- a/spec/services/platform/user_filestore_payload_spec.rb
+++ b/spec/services/platform/user_filestore_payload_spec.rb
@@ -1,33 +1,42 @@
 RSpec.describe Platform::UserFilestorePayload do
   subject(:user_filestore_payload) do
-    described_class.new(file_details)
+    described_class.new(session, file_details: file_details, service_secret: service_secret)
+  end
+  let(:session) do
+    {
+      session_id: '04cf476c2dd02e01304d7ab321764096',
+      user_token: '162738e2772348798c657c64c226042e'
+    }
+  end
+  let(:service_secret) do
+    '499bed391d8d3c937421c4254a0d2b0e'
   end
 
   describe '#call' do
     context 'valid payload' do
       let(:expected_payload) do
         {
-          "encrypted_user_id_and_token": '12345678901234567890123456789012',
-          "file": Base64.strict_encode64("THIS IS A KNIFE!\n"),
-          "policy": {
-            "max_size": Platform::UserFilestorePayload::MAX_FILE_SIZE,
-            "allowed_types": Platform::UserFilestorePayload::ALLOWED_TYPES,
-            "expires": Platform::UserFilestorePayload::DEFAULT_EXPIRATION
+          'encrypted_user_id_and_token': "/7danQNZrt06+SZlQUOjsxcRvy9wiuW6Y9lxQg9EF4s8TaXc/Ez/UK2LZkKQ\n/NR0T8WJJTJB3HKlLj3V2F5iWQ==\n",
+          'file': Base64.strict_encode64("THIS IS A KNIFE!\n"),
+          'policy': {
+            'max_size': Platform::UserFilestorePayload::MAX_FILE_SIZE,
+            'allowed_types': Platform::UserFilestorePayload::ALLOWED_TYPES,
+            'expires': Platform::UserFilestorePayload::DEFAULT_EXPIRATION
           }
         }
       end
       let(:file_details) do
         {
-          "tempfile" => upload_file,
-          "original_filename" => "thats-not-a-knife.txt",
-          "content_type" => "plain/txt",
-          "headers" => "Content-Type: plain/txt"
+          'tempfile' => upload_file,
+          'original_filename' => 'thats-not-a-knife.txt',
+          'content_type' => 'plain/txt',
+          'headers' => 'Content-Type: plain/txt'
         }
       end
 
       let(:upload_file) do
         Rack::Test::UploadedFile.new(
-          "./spec/fixtures/thats-not-a-knife.txt", "plain/txt"
+          './spec/fixtures/thats-not-a-knife.txt', 'plain/txt'
         )
       end
 

--- a/spec/services/platform/user_filestore_payload_spec.rb
+++ b/spec/services/platform/user_filestore_payload_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Platform::UserFilestorePayload do
+  subject(:user_filestore_payload) do
+    described_class.new(file_details)
+  end
+
+  describe '#call' do
+    context 'valid payload' do
+      let(:expected_payload) do
+        {
+          "encrypted_user_id_and_token": '12345678901234567890123456789012',
+          "file": Base64.strict_encode64("THIS IS A KNIFE!\n"),
+          "policy": {
+            "max_size": Platform::UserFilestorePayload::MAX_FILE_SIZE,
+            "allowed_types": Platform::UserFilestorePayload::ALLOWED_TYPES,
+            "expires": Platform::UserFilestorePayload::DEFAULT_EXPIRATION
+          }
+        }
+      end
+      let(:file_details) do
+        {
+          "tempfile" => upload_file,
+          "original_filename" => "thats-not-a-knife.txt",
+          "content_type" => "plain/txt",
+          "headers" => "Content-Type: plain/txt"
+        }
+      end
+
+      let(:upload_file) do
+        Rack::Test::UploadedFile.new(
+          "./spec/fixtures/thats-not-a-knife.txt", "plain/txt"
+        )
+      end
+
+      it 'returns correct payload' do
+        expect(user_filestore_payload.call).to eq(expected_payload)
+      end
+    end
+  end
+end

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -86,4 +86,8 @@ class VersionFixture < SitePrism::Page
   def star_wars_knowledge_2_checkanswers
     summary_list[9]
   end
+
+  def dog_picture_checkanswers
+    summary_list[10]
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/alACDOD0/1556-file-upload-upload-a-file-to-the-form)

## Context

Feature upload in the runner.

There two adapters:

1. The filestore adapter which at this point only send the file to the filestore
2. Offline adapter used for local development. This is not yet implemented and will be implemented on this card: https://trello.com/c/1hsH2Qpk/1224-file-upload-editor-preview

## Page answers object 

The page answers object will hold the uploaded files (the `UploadedFile` class) coming from the adapters in order to use in the validation process.

## Done!

We need to:

1. merge the metadata presenter gem first on https://github.com/ministryofjustice/fb-metadata-presenter/compare/feature/upload-files?expand=1
2. Change the Gemfile on this PR