### PR TITLE
Exclude health endpoint from sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,8 +1,16 @@
+EXCLUDE_PATHS = %w[/health /robots.txt].freeze
+
 Sentry.init do |config|
   config.breadcrumbs_logger = [:active_support_logger, :http_logger]
   config.logger =  Logger.new(STDOUT)
 
-  config.traces_sample_rate = 1
+  config.traces_sampler = lambda do |sampling_context|
+    transaction_context = sampling_context[:transaction_context]
+    transaction_name = transaction_context[:name]
+
+    !transaction_name.in?(EXCLUDE_PATHS)
+  end
+
   config.before_send = lambda do |event, _hint|
     if event.request && event.request.data
       filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)


### PR DESCRIPTION
`/health` is used by Kubernetes to check whether the container is ok. We
do not need this to make it to Sentry.

Following the docs here:

https://docs.sentry.io/platforms/ruby/configuration/sampling/

Returning true would set the sample rate to 1 which means every request
is sent to Sentry. Returning false sets it to 0 so the the transaction
is not sent.

`sentry: [Tracing] Discarding <rails.request> transaction </health> because traces_sampler returned 0 or false`

In the future it may be necessary to adjust the sample rate so that it
is not 100% of all transactions, but for the purposes of the trial it
will do for now.