### PR TITLE
Fix optional answers

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -76,6 +76,8 @@ module Platform
           Date.civil(answer.year.to_i, answer.month.to_i, answer.day.to_i),
           format: '%d %B %Y'
         )
+      elsif component.type == 'checkboxes'
+        answer.to_a
       else
         answer
       end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -191,7 +191,8 @@ RSpec.describe Platform::SubmitterPayload do
             {
               'holiday_date_1(3i)' => '',
               'holiday_date_1(2i)' => '',
-              'holiday_date_1(1i)' => ''
+              'holiday_date_1(1i)' => '',
+              'burgers_checkboxes_1' => nil
             }
           )
         )
@@ -210,6 +211,20 @@ RSpec.describe Platform::SubmitterPayload do
           field_id: 'holiday_date_1',
           field_name: 'What is the day that you like to take holidays?',
           answer: ''
+        })
+      end
+
+      let(:checkbox_answer) do
+        answers.flatten.find { |answer| answer[:field_id] == 'burgers_checkboxes_1' }
+      end
+
+      it 'sends pages with blank checkboxes' do
+        expect(
+          checkbox_answer
+        ).to eq({
+          field_id: 'burgers_checkboxes_1',
+          field_name: 'What would you like on your burger?',
+          answer: []
         })
       end
     end


### PR DESCRIPTION
At present, when a user does not answer an optional checkbox question the service breaks.
This fix ensures any optional checkboxes without an answer comes back as an empty array.

Story: https://trello.com/c/tKIY7H1I/1292-bug-published-forms-with-optional-questions-and-email-configuration-active-unable-to-reach-the-confirmation-page-after-cya-occur

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
