### PR TITLE
Additional upload mimetypes

### DIFF
--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -4,11 +4,13 @@ module Platform
 
     DEFAULT_EXPIRATION = 28
     ALLOWED_TYPES = %w[
+      text/csv
       text/plain
       application/vnd.openxmlformats-officedocument.wordprocessingml.document
       application/msword
       application/vnd.oasis.opendocument.text
       application/pdf
+      application/rtf
       image/jpeg
       image/png
       application/vnd.ms-excel


### PR DESCRIPTION
Add csv and rtf mimetypes to the default allowed file upload types