### PR TITLE
Use allowed file types from component metadata

### DIFF
--- a/app/models/file_uploader.rb
+++ b/app/models/file_uploader.rb
@@ -17,7 +17,8 @@ class FileUploader
     else
       user_filestore_payload = Platform::UserFilestorePayload.new(
         session,
-        file_details: file_details
+        file_details: file_details,
+        allowed_file_types: component.validation['accept']
       ).call
 
       Platform::UserFilestoreAdapter.new(

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -1,6 +1,6 @@
 module Platform
   class UserFilestorePayload
-    attr_reader :session, :file_details, :service_secret
+    attr_reader :session, :file_details, :service_secret, :allowed_file_types
 
     DEFAULT_EXPIRATION = 28
     ALLOWED_TYPES = %w[
@@ -17,10 +17,11 @@ module Platform
     ].freeze
     MAX_FILE_SIZE = 7_340_032
 
-    def initialize(session, file_details:, service_secret: ENV['SERVICE_SECRET'])
+    def initialize(session, file_details:, allowed_file_types:, service_secret: ENV['SERVICE_SECRET'])
       @session = session
       @file_details = file_details
       @service_secret = service_secret
+      @allowed_file_types = allowed_file_types
     end
 
     def call
@@ -40,7 +41,7 @@ module Platform
     end
 
     def allowed_types
-      ALLOWED_TYPES
+      allowed_file_types || ALLOWED_TYPES
     end
 
     def temp_file

--- a/spec/models/file_uploader_spec.rb
+++ b/spec/models/file_uploader_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe FileUploader do
       }
     )
   end
-  let(:component) { double(id: 'dog-picture') }
+  let(:component) { double(id: 'dog-picture', validation: { 'accept' => %w[text/csv] }) }
 
   before do
     allow(ENV).to receive(:[])


### PR DESCRIPTION
Going forward we need to be able to take the allowed file types for a
given component from the metadata and pass that onto the filestore when
required as the filestore is the one that checks the types.

The default list of allowed file types should also be generated at the
same time as a new file upload component is created.