### PR TITLE
Remove carriage return from encryption

### DIFF
--- a/app/models/data_encryption.rb
+++ b/app/models/data_encryption.rb
@@ -16,7 +16,7 @@ class DataEncryption
     result = cipher.update(data)
     result << cipher.final
 
-    Base64.encode64(result)
+    Base64.strict_encode64(result)
   end
 
   def decrypt(data)
@@ -24,7 +24,7 @@ class DataEncryption
     cipher.key = key
     cipher.iv = iv
     raw_decrypted_data = cipher.update(
-      Base64.decode64(data)
+      Base64.strict_decode64(data)
     )
     raw_decrypted_data << cipher.final
 

--- a/app/models/data_encryption.rb
+++ b/app/models/data_encryption.rb
@@ -23,11 +23,18 @@ class DataEncryption
     cipher.decrypt
     cipher.key = key
     cipher.iv = iv
-    raw_decrypted_data = cipher.update(
-      Base64.strict_decode64(data)
-    )
+    raw_decrypted_data = cipher.update(decode_64(data))
     raw_decrypted_data << cipher.final
 
     raw_decrypted_data
+  end
+
+  private
+
+  def decode_64(data)
+    Base64.strict_decode64(data)
+  rescue ArgumentError
+    Rails.logger.info('Strict decode failed. Attempting standard decode')
+    Base64.decode64(data)
   end
 end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -43,7 +43,8 @@ module Platform
           from: ENV['SERVICE_EMAIL_FROM'],
           subject: ENV['SERVICE_EMAIL_SUBJECT'],
           email_body: ENV['SERVICE_EMAIL_BODY'],
-          include_pdf: true
+          include_pdf: true,
+          include_attachments: true
         }
       ]
     end

--- a/spec/models/data_encryption_spec.rb
+++ b/spec/models/data_encryption_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe DataEncryption do
 
   context 'when encrypting and decrypting the payload' do
     it 'encrypts the payload' do
-      expect(data_encryption.encrypt(data)).to eq("acYk")
+      expect(data_encryption.encrypt(data)).to eq('acYk')
     end
 
     it 'decrypts the encrypted payload' do
-      expect(data_encryption.decrypt("acYk")).to eq('foo')
+      expect(data_encryption.decrypt('acYk')).to eq('foo')
     end
   end
 
@@ -24,6 +24,15 @@ RSpec.describe DataEncryption do
     it 'fails to decrypt' do
       encrypted_data = data_encryption.encrypt(data)
       expect(another_data_encryption.decrypt(encrypted_data)).to_not eq('foo')
+    end
+  end
+
+  context 'when strict_decode64 fails' do
+    it 'should attempt standard decode64' do
+      encrypted_data = Base64.encode64(data)
+
+      expect(Base64).to receive(:decode64).with(encrypted_data).and_return('foo')
+      data_encryption.decrypt(encrypted_data)
     end
   end
 end

--- a/spec/models/data_encryption_spec.rb
+++ b/spec/models/data_encryption_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe DataEncryption do
 
   context 'when encrypting and decrypting the payload' do
     it 'encrypts the payload' do
-      expect(data_encryption.encrypt(data)).to eq("acYk\n")
+      expect(data_encryption.encrypt(data)).to eq("acYk")
     end
 
     it 'decrypts the encrypted payload' do
-      expect(data_encryption.decrypt("acYk\n")).to eq('foo')
+      expect(data_encryption.decrypt("acYk")).to eq('foo')
     end
   end
 

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -191,7 +191,8 @@ RSpec.describe Platform::SubmitterPayload do
           from: email_from,
           subject: email_subject,
           email_body: email_body,
-          include_pdf: true
+          include_pdf: true,
+          include_attachments: true
         }
       ]
     end

--- a/spec/services/platform/user_filestore_payload_spec.rb
+++ b/spec/services/platform/user_filestore_payload_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Platform::UserFilestorePayload do
     context 'valid payload' do
       let(:expected_payload) do
         {
-          'encrypted_user_id_and_token': "/7danQNZrt06+SZlQUOjsxcRvy9wiuW6Y9lxQg9EF4s8TaXc/Ez/UK2LZkKQ\n/NR0T8WJJTJB3HKlLj3V2F5iWQ==\n",
+          'encrypted_user_id_and_token': "/7danQNZrt06+SZlQUOjsxcRvy9wiuW6Y9lxQg9EF4s8TaXc/Ez/UK2LZkKQ/NR0T8WJJTJB3HKlLj3V2F5iWQ==",
           'file': Base64.strict_encode64("THIS IS A KNIFE!\n"),
           'policy': {
             'max_size': Platform::UserFilestorePayload::MAX_FILE_SIZE,

--- a/spec/services/platform/user_filestore_payload_spec.rb
+++ b/spec/services/platform/user_filestore_payload_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Platform::UserFilestorePayload do
     context 'valid payload' do
       let(:expected_payload) do
         {
-          'encrypted_user_id_and_token': "/7danQNZrt06+SZlQUOjsxcRvy9wiuW6Y9lxQg9EF4s8TaXc/Ez/UK2LZkKQ/NR0T8WJJTJB3HKlLj3V2F5iWQ==",
+          'encrypted_user_id_and_token': '/7danQNZrt06+SZlQUOjsxcRvy9wiuW6Y9lxQg9EF4s8TaXc/Ez/UK2LZkKQ/NR0T8WJJTJB3HKlLj3V2F5iWQ==',
           'file': Base64.strict_encode64("THIS IS A KNIFE!\n"),
           'policy': {
             'max_size': Platform::UserFilestorePayload::MAX_FILE_SIZE,


### PR DESCRIPTION
## Strict encode and decode base 64 on data encryption

Use strict encoding when base64 encoding during data encryption and decryption

## Add include attachments to true on submission

This will make the uploaded files be sent to the form owner

## Attempt standard decode64 if strict_decode64 fails

In Ruby's standard library when using standard encode64 on a string CR
and LF characters are injected into it. This was causing the encrypted-user-id-and-token
header that is checked during JWT authentication between the submitter
and the filestore to fail with and ArgumentError. It is not able to
correctly decode the CR and LF characters.

In order get round this we changed the encoding mechanism to use
strict_encode64 which resolves that issue. However we need to be able to
cater for both when we deploy as there will still be users
interacting with the forms which will have encoded the encrypted-user-id-and-token
using the standard encode64 method.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>