### PR TITLE
Make sure the submission is sent even if service secret is blank

### DIFF
--- a/app/services/platform/encrypted_user_id_and_token.rb
+++ b/app/services/platform/encrypted_user_id_and_token.rb
@@ -1,6 +1,8 @@
 module Platform
   module EncryptedUserIdAndToken
     def encrypted_user_id_and_token
+      return '' if service_secret.blank?
+
       DataEncryption.new(
         key: service_secret
       ).encrypt("#{user_id}#{session[:user_token]}")


### PR DESCRIPTION
## Context

We need to handle the case where the env SERVICE_SECRET is blank for forms which don't have the file upload yet and it is not published before the SERVICE_SECRET env var was added.

If the service secret is blank we should continue with the submission.