### PR TITLE
Fix optional file upload components

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -82,7 +82,7 @@ module Platform
       elsif component.type == 'checkboxes'
         answer.to_a
       elsif component.upload?
-        answer['original_filename']
+        answer['original_filename'] || ''
       else
         answer
       end
@@ -111,7 +111,7 @@ module Platform
     end
 
     def answered_upload_components
-      upload_components.map { |component| user_data[component.id] }.compact
+      upload_components.map { |component| user_data[component.id] }.compact.reject(&:blank?)
     end
 
     def upload_components

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -222,7 +222,8 @@ RSpec.describe Platform::SubmitterPayload do
               'holiday_date_1(3i)' => '',
               'holiday_date_1(2i)' => '',
               'holiday_date_1(1i)' => '',
-              'burgers_checkboxes_1' => nil
+              'burgers_checkboxes_1' => nil,
+              'dog-picture_upload_1' => {}
             }
           ),
           session: session
@@ -256,6 +257,20 @@ RSpec.describe Platform::SubmitterPayload do
           field_id: 'burgers_checkboxes_1',
           field_name: 'What would you like on your burger?',
           answer: []
+        })
+      end
+
+      let(:upload_answer) do
+        answers.flatten.find { |answer| answer[:field_id] == 'dog-picture_upload_1' }
+      end
+
+      it 'sends an empty string if file uploads have no uploaded file' do
+        expect(
+          upload_answer
+        ).to eq({
+          field_id: 'dog-picture_upload_1',
+          field_name: 'Upload your best dog photo',
+          answer: ''
         })
       end
     end
@@ -318,7 +333,7 @@ RSpec.describe Platform::SubmitterPayload do
       end
 
       context 'with optional file upload questions ie no answer in user data' do
-        let(:user_data) { {} }
+        let(:user_data) { { 'dog-picture_upload_1' => {} } }
 
         it 'sends an empty array in the attachments' do
           expect(submitter_payload.to_h[:attachments]).to eq([])


### PR DESCRIPTION
When a file upload component is optional what is actually saved in the
user_data object is a `{}`. e.g `{ 'dog-picture_upload_1' => {} }`

This is ok as when we get to the summary we will want to show that there
was a file upload question, but since it's optional there may or may not
be a file name.

However we cannot send `nil` in the submission payload as this fails
schema validation in the Submitter. So instead we send an `''`. The PDF
generator should then correctly iterate over the answer and just present
the name of the question but with no name of the file.

When it comes to the attachments we should just not include the file
object associated with that question at all if the user hasn't actually
uploaded a file.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>