### PR TITLE
Cater for optional checkbox answers

### DIFF
--- a/app/models/user_data_params.rb
+++ b/app/models/user_data_params.rb
@@ -5,13 +5,33 @@ class UserDataParams
   end
 
   def answers
+    set_uploaded_file_details
+    set_optional_checkboxes
+
+    @answer_params
+  end
+
+  private
+
+  def set_uploaded_file_details
     if @page_answers.uploaded_files.present?
       @page_answers.uploaded_files.map do |uploaded_file|
         @answer_params[uploaded_file.component.id] =
           @page_answers.send(uploaded_file.component.id).merge(uploaded_file.file)
       end
     end
+  end
 
-    @answer_params
+  def set_optional_checkboxes
+    checkbox_components.each do |component|
+      @answer_params[component.id] = [] if @page_answers.send(component.id).blank?
+    end
+  end
+
+  def checkbox_components
+    # not all pages have components
+    Array(@page_answers.page.components).select do |component|
+      component.type == 'checkboxes'
+    end
   end
 end

--- a/spec/models/user_data_params_spec.rb
+++ b/spec/models/user_data_params_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe UserDataParams do
       end
     end
 
+    context 'page with checkbox components' do
+      let(:page) { service.find_page_by_url('burgers') }
+
+      context 'when optional' do
+        let(:answers) { {} }
+        let(:expected_answers) { { 'burgers_checkboxes_1' => [] } }
+
+        it 'should set an empty array for unanswered optional checkboxes' do
+          expect(user_data_params.answers).to eq(expected_answers)
+        end
+      end
+    end
+
     context 'when other answers' do
       let(:page) { service.find_page_by_url('name') }
       let(:answers) { { 'name_text_1' => 'John Wick' } }


### PR DESCRIPTION
This fixes a for when checkboxes are optional and a user does not pick
any of the choices.

If the user had not previously answered the question and had proceeded
through the rest of the form and submitted this would be fine.

However in the event the user comes back to the checkboxes page and
unticks all of the items then this was not reflected in the saved
answers. This is because the frontend has no concept of what the user
has saved at that point and does not post anything relating to that
answer to the backend at all. Therefore their previous answer was never
overwritten.

In those instances where there is no answer for a checkbox page we set
an empty array against that components corresponding ID in their user
answers therefore overwriting any previous answer that they may have
had.