### PR TITLE
Bump metadata presenter to v1.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-gem 'metadata_presenter', '1.7.0'
+gem 'metadata_presenter', '1.7.1'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (1.7.0)
+    metadata_presenter (1.7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   jwt
   listen (~> 3.5)
-  metadata_presenter (= 1.7.0)
+  metadata_presenter (= 1.7.1)
   prometheus-client (~> 2.1.0)
   puma (~> 5.3)
   rails (~> 6.1.4)


### PR DESCRIPTION
Story: https://trello.com/c/oLpW8JdV/1599-confirm-code-snippets-are-not-saved-into-the-metadata

Relates to: https://github.com/ministryofjustice/fb-metadata-presenter/pull/152