### PR TITLE
Send answered pages based on branching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,12 @@ gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 # gem 'metadata_presenter',
-#   github: 'ministryofjustice/fb-metadata-presenter',
-#   branch: 'check-your-answers'
+#  github: 'ministryofjustice/fb-metadata-presenter',
+#  branch: 'branching-submission'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-gem 'metadata_presenter', '1.8.1'
+gem 'metadata_presenter', '1.9.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (1.8.1)
+    metadata_presenter (1.9.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   jwt
   listen (~> 3.5)
-  metadata_presenter (= 1.8.1)
+  metadata_presenter (= 1.9.0)
   prometheus-client (~> 2.1.0)
   puma (~> 5.3)
   rails (~> 6.1.4)

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -50,7 +50,7 @@ module Platform
     end
 
     def pages
-      service.pages.map { |page|
+      answered_pages.map { |page|
         components = strip_content_components(page.components)
         next if components.empty?
 
@@ -65,6 +65,10 @@ module Platform
           end
         }
       }.compact
+    end
+
+    def answered_pages
+      MetadataPresenter::TraversedPages.new(service, user_data).all
     end
 
     def answer_for(page, component)

--- a/spec/features/branching_spec.rb
+++ b/spec/features/branching_spec.rb
@@ -91,6 +91,8 @@ RSpec.feature 'Navigation' do
     then_I_should_be_on_check_your_answers_page
 
     and_I_should_see_only_the_question_and_answers_based_on_branching
+    and_I_send_my_application
+    then_I_should_see_the_confirmation_message
   end
 
   def and_I_should_see_only_the_question_and_answers_based_on_branching

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -222,10 +222,6 @@ RSpec.feature 'Navigation' do
     )
   end
 
-  def and_I_send_my_application
-    form.accept_and_send_button.click
-  end
-
   def and_I_change_my_full_name_answer
     form.full_name_change_answer_link.click
     form.full_name_field.set('Jabba')
@@ -253,14 +249,6 @@ RSpec.feature 'Navigation' do
     expect(form.text).to include(
       "The page you were looking for doesn't exist (404)"
     )
-  end
-
-  def then_I_should_see_the_confirmation_message
-    expect(form.confirmation_heading.text).to eq('Complaint sent')
-    expect(
-      form.confirmation_body.text.gsub('’', "'") # shrug
-    ).to eq('Some day I will be the most powerful Jedi ever!')
-    expect(form.text).not_to include('Optional lede')
   end
 
   def then_I_should_see_my_changed_full_name_on_check_your_answers

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe Platform::SubmitterPayload do
     let(:service_payload) do
       {
         id: service.service_id,
-        slug: 'version-fixture',
+        slug: service.service_slug,
         name: service.service_name
       }
     end
@@ -211,6 +211,86 @@ RSpec.describe Platform::SubmitterPayload do
         .and_return(email_subject)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_BODY')
         .and_return(email_body)
+    end
+
+    context 'when branching' do
+      let(:service_metadata) { metadata_fixture(:branching) }
+      let(:user_data) do
+        {
+          'name_text_1' => 'Thor',
+          'do-you-like-star-wars_radios_1' => 'Hell no!',
+          'favourite-fruit_radios_1' => 'Apples',
+          'apple-juice_radios_1' => 'Yes',
+          # Below, this answer will be ignored because
+          # the user's favourite fruit is Apples
+          'orange-juice_radios_1' => 'Yes',
+          'favourite-band_radios_1' => 'Beatles',
+          'music-app_radios_1' => 'iTunes',
+          'best-formbuilder_radios_1' => 'Others',
+          'burgers_checkboxes_1' => ['Mozzarella, cheddar, feta'],
+          'marvel-series_radios_1' => 'Loki',
+          'best-arnold-quote_checkboxes_1' => [
+            'You are not you. You are me',
+            'Get to the chopper',
+            'You have been terminated'
+          ],
+          'which-formbuilder_text_1' => 'MoJ again!'
+        }
+      end
+      let(:pages_payload) do
+        [
+          {
+            heading: '',
+            answers: [{ field_id: 'name_text_1', field_name: 'Full name', answer: 'Thor' }]
+          },
+          { heading: '',
+            answers: [{ field_id: 'do-you-like-star-wars_radios_1',
+                        field_name: 'Do you like Star Wars?',
+                        answer: 'Hell no!' }] },
+          { heading: '',
+            answers: [{ field_id: 'favourite-fruit_radios_1',
+                        field_name: 'What is your favourite fruit?',
+                        answer: 'Apples' }] },
+          { heading: '',
+            answers: [{ field_id: 'apple-juice_radios_1',
+                        field_name: 'Do you like apple juice?',
+                        answer: 'Yes' }] },
+          { heading: '',
+            answers: [{ field_id: 'favourite-band_radios_1',
+                        field_name: 'What is your favourite band?',
+                        answer: 'Beatles' }] },
+          { heading: '',
+            answers: [{ field_id: 'music-app_radios_1',
+                        field_name: 'Which app do you use to listen music?',
+                        answer: 'iTunes' }] },
+          { heading: '',
+            answers: [{ field_id: 'best-formbuilder_radios_1',
+                        field_name: 'What is the best form builder?',
+                        answer: 'Others' }] },
+          { heading: '',
+            answers: [{ field_id: 'which-formbuilder_text_1',
+                        field_name: 'Which Formbuilder is the best?',
+                        answer: 'MoJ again!' }] },
+          { heading: '',
+            answers: [{ field_id: 'burgers_checkboxes_1',
+                        field_name: 'What would you like on your burger?',
+                        answer: ['Mozzarella, cheddar, feta'] }] },
+          { heading: '',
+            answers: [{ field_id: 'marvel-series_radios_1',
+                        field_name: 'What is the best marvel series?',
+                        answer: 'Loki' }] },
+          { heading: '',
+            answers: [{ field_id: 'best-arnold-quote_checkboxes_1',
+                        field_name: 'Select all Arnold Schwarzenegger quotes',
+                        answer: ['You are not you. You are me',
+                                 'Get to the chopper',
+                                 'You have been terminated'] }] }
+        ]
+      end
+
+      it 'sends right pages and ignores answers based on branching' do
+        expect(submitter_payload.to_h[:pages]).to eq(pages_payload)
+      end
     end
 
     context 'when optional fields' do

--- a/spec/support/helpers/feature_steps.rb
+++ b/spec/support/helpers/feature_steps.rb
@@ -11,6 +11,10 @@ module FeatureSteps
     form.continue_button.click
   end
 
+  def and_I_send_my_application
+    form.accept_and_send_button.click
+  end
+
   def and_I_add_my_full_name
     form.full_name_field.set('Han Solo')
     and_I_go_to_next_page
@@ -56,5 +60,13 @@ module FeatureSteps
     expected_message = [message]
     expect(form.error_summary).to eq(expected_message)
     expect(form.error_messages).to eq(expected_message)
+  end
+
+  def then_I_should_see_the_confirmation_message
+    expect(form.confirmation_heading.text).to eq('Complaint sent')
+    expect(
+      form.confirmation_body.text.gsub('’', "'") # shrug
+    ).to eq('Some day I will be the most powerful Jedi ever!')
+    expect(form.text).not_to include('Optional lede')
   end
 end

--- a/spec/support/pages/branching_fixture.rb
+++ b/spec/support/pages/branching_fixture.rb
@@ -24,6 +24,9 @@ class BranchingFixture < SitePrism::Page
   element :continue_button, :button, 'Continue'
   elements :summary_list, '.govuk-summary-list__row'
   element :accept_and_send_button, :button, 'Accept and send application'
+  element :confirmation_heading, '.govuk-panel__title'
+  data_content_id :confirmation_lede, 'page[lede]'
+  data_content_id :confirmation_body, 'page[body]'
 
   def check_your_answers_list
     summary_list.map do |element|


### PR DESCRIPTION
The traversed pages object will traverse to all pages and
evaluates the branches and selects the answers from user
data **whatever** the user data contains.

The user data can contain all answers for all pages in all branches!
But it is up to the `TraversedPages` object to decide which one
will be include in the submission.