### PR TITLE
Remove back links from standalone pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-gem 'metadata_presenter', '1.9.0'
+gem 'metadata_presenter', '2.1.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.3'
 gem 'rails', '~> 6.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (1.9.0)
+    metadata_presenter (2.1.0)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -338,7 +338,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   jwt
   listen (~> 3.6)
-  metadata_presenter (= 1.9.0)
+  metadata_presenter (= 2.1.0)
   prometheus-client (~> 2.1.0)
   puma (~> 5.3)
   rails (~> 6.1.4)

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -100,10 +100,6 @@ RSpec.feature 'Navigation' do
   scenario 'when I go back from a standalone page' do
     when_I_visit_the_name_page
     and_I_click_the_cookies_page
-    and_I_go_back
-    then_I_should_be_on_the_name_page
-    and_I_go_back
-    then_I_should_be_on_the_start_page
     and_I_should_not_see_any_back_link
   end
 
@@ -114,14 +110,6 @@ RSpec.feature 'Navigation' do
   def and_I_click_the_cookies_page
     click_link 'Cookies'
     expect(form.current_path).to eq('/cookies')
-  end
-
-  def then_I_should_be_on_the_name_page
-    expect(form.current_path).to eq('/name')
-  end
-
-  def then_I_should_be_on_the_start_page
-    expect(form.current_path).to eq('/')
   end
 
   def and_I_should_not_see_any_back_link


### PR DESCRIPTION
We no longer want to have back links on standalone pages so remove
associated tests for it and also use the latest presenter