### PR TITLE
Send the user id in file url to submitter

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -1,5 +1,6 @@
 module Platform
   class SubmitterPayload
+    include Platform::Connection
     attr_reader :service, :user_data, :session
 
     EMAIL = 'email'.freeze
@@ -128,7 +129,7 @@ module Platform
     def file_download_url(fingerprint)
       "#{ENV['USER_FILESTORE_URL']}" \
       "/service/#{ENV['SERVICE_SLUG']}" \
-      "/user/#{session[:session_id]}" \
+      "/user/#{user_id}" \
       "/#{fingerprint}"
     end
   end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Platform::SubmitterPayload do
-  let(:session) { { session_id: '1234' } }
+  let(:session) { { user_id: 'user-id-5b10c947cf32bd0558318e77eebc0995' } }
   subject(:submitter_payload) do
     described_class.new(
       service: service,
@@ -403,7 +403,23 @@ RSpec.describe Platform::SubmitterPayload do
           expect(submitter_payload.to_h[:attachments]).to eq(
             [
               {
-                url: 'https://www.yeah-baby.com/service/groovy/user/1234/28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
+                url: 'https://www.yeah-baby.com/service/groovy/user/user-id-5b10c947cf32bd0558318e77eebc0995/28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
+                filename: 'basset-hound.jpg',
+                mimetype: 'image/jpg'
+              }
+            ]
+          )
+        end
+      end
+
+      context 'when there is no user id' do
+        let(:session) { { session_id: 'bf264550118dc32eef61f1b2e1206a58' } }
+
+        it 'sends the correct attachments object in the payload' do
+          expect(submitter_payload.to_h[:attachments]).to eq(
+            [
+              {
+                url: 'https://www.yeah-baby.com/service/groovy/user/bf264550118dc32eef61f1b2e1206a58/28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
                 filename: 'basset-hound.jpg',
                 mimetype: 'image/jpg'
               }


### PR DESCRIPTION
Use the user id always (when uploading and when asking to submitter
to download) and If we don't have use the session_id.

If we don't do this when the Submitter downloads the file,
the user_id and session_id won't match. Conclusion: it should be
the same id that you sent the file.

When we send the file to filestore we attach an user id to it.
When we pass to submitter the attachment the id should be the same
one that you sent. Given that this PR fix this issue.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>