### PR TITLE
Remove session id from data management

### DIFF
--- a/app/models/user_data.rb
+++ b/app/models/user_data.rb
@@ -25,11 +25,6 @@ class UserData
   end
 
   def create_user_keys
-    if session[:user_token].present?
-      # backwards compatibility to avoid erasing user data during the deployment
-      session[:user_id] ||= session[:session_id]
-    end
-
     session[:user_token] ||= SecureRandom.hex(16)
     session[:user_id] ||= SecureRandom.hex(16)
   end

--- a/app/services/platform/connection.rb
+++ b/app/services/platform/connection.rb
@@ -35,7 +35,7 @@ module Platform
     end
 
     def subject
-      session[:user_id] || session[:session_id]
+      session[:user_id]
     end
     alias_method :user_id, :subject
 

--- a/spec/models/user_data_spec.rb
+++ b/spec/models/user_data_spec.rb
@@ -57,24 +57,9 @@ RSpec.describe UserData do
       end
     end
 
-    context 'when there is a user token but no user id' do
-      let(:session) do
-        {
-          session_id: '627b1048ab1d29539510abc89b79833f',
-          user_token: '6dd78844fb69d634f22143401cfb1851'
-        }
-      end
-
-      it 'assigns session_id as the user_id (to be backwards compatible)' do
-        user_data.adapter
-        expect(session[:user_id]).to eq('627b1048ab1d29539510abc89b79833f')
-      end
-    end
-
     context 'when there is a user token and an user id' do
       let(:session) do
         {
-          session_id: '627b1048ab1d29539510abc89b79833f',
           user_token: '6dd78844fb69d634f22143401cfb1851',
           user_id: '192ba011389fe2f15039b3b717a754f9'
         }

--- a/spec/services/platform/submitter_adapter_spec.rb
+++ b/spec/services/platform/submitter_adapter_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Platform::SubmitterAdapter do
   let(:session) do
     {
       user_id: 'aed3fa4fae7c784cc7675eeb539669c1',
-      session_id: 'fa018e7bef6460c2a52818bab9731304',
       user_token: '648f6ae5d954373e85769165acf23a9a'
     }
   end
@@ -93,29 +92,6 @@ RSpec.describe Platform::SubmitterAdapter do
         body.merge({
           encrypted_user_id_and_token: ''
         })
-      end
-      include_context 'request to submitter'
-    end
-
-    context 'when user id in the session is not present' do
-      let(:expected_body) { body }
-      let(:session) do
-        {
-          session_id: 'fa018e7bef6460c2a52818bab9731304',
-          user_token: '648f6ae5d954373e85769165acf23a9a'
-        }
-      end
-      let(:jwt_subject) { session[:session_id] }
-      let(:body) do
-        {
-          encrypted_submission: DataEncryption.new(key: key).encrypt(
-            JSON.generate(payload)
-          ),
-          service_slug: service_slug,
-          encrypted_user_id_and_token: DataEncryption.new(key: service_secret).encrypt(
-            "#{session[:session_id]}#{session[:user_token]}"
-          )
-        }
       end
       include_context 'request to submitter'
     end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -412,22 +412,6 @@ RSpec.describe Platform::SubmitterPayload do
         end
       end
 
-      context 'when there is no user id' do
-        let(:session) { { session_id: 'bf264550118dc32eef61f1b2e1206a58' } }
-
-        it 'sends the correct attachments object in the payload' do
-          expect(submitter_payload.to_h[:attachments]).to eq(
-            [
-              {
-                url: 'https://www.yeah-baby.com/service/groovy/user/bf264550118dc32eef61f1b2e1206a58/28d-6dbfe5a3fff4a67260e7057e49b13ae0794598a949907a',
-                filename: 'basset-hound.jpg',
-                mimetype: 'image/jpg'
-              }
-            ]
-          )
-        end
-      end
-
       context 'with optional file upload questions ie no answer in user data' do
         let(:user_data) { { 'dog-picture_upload_1' => {} } }
 

--- a/spec/services/platform/user_datastore_adapter_spec.rb
+++ b/spec/services/platform/user_datastore_adapter_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe Platform::UserDatastoreAdapter do
   let(:session) do
     {
       user_id: '60abfdea862c0c6d7aa737aec6e805fa',
-      session_id: '8b62ea25319b4ad8a889174dca57e061',
       user_token: '474c39bf61287d4ec0aa1276f089d2e3'
     }
   end
@@ -146,32 +145,6 @@ RSpec.describe Platform::UserDatastoreAdapter do
   end
 
   describe '#load_data' do
-    context 'when there is no user id in the session' do
-      let(:session) do
-        {
-          session_id: '8b62ea25319b4ad8a889174dca57e061',
-          user_token: '474c39bf61287d4ec0aa1276f089d2e3'
-        }
-      end
-      let(:expected_url) do
-        URI.join(root_url, '/service/court-service/user/8b62ea25319b4ad8a889174dca57e061')
-      end
-
-      before do
-        stub_request(:get, expected_url)
-          .with(body: {}, headers: expected_headers)
-          .to_return(status: 200, body: expected_body, headers: {})
-      end
-
-      it 'fallback to the session id' do
-        adapter.load_data
-        expect(WebMock).to have_requested(
-          :get, expected_url
-        ).with(headers: expected_headers)
-         .once
-      end
-    end
-
     context 'when returning data' do
       before do
         stub_request(:get, expected_url)

--- a/spec/services/platform/user_filestore_adapter_spec.rb
+++ b/spec/services/platform/user_filestore_adapter_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Platform::UserFilestoreAdapter do
       'X-Access-Token-V2' => ''
     }
   end
-  let(:session) { { session_id: 'some-id', user_id: 'bassetthegodfather' } }
+  let(:session) { { user_id: 'bassetthegodfather' } }
   let(:expected_url) do
     "#{root_url}/service/#{service_slug}/user/#{session[:user_id]}"
   end
@@ -80,23 +80,6 @@ RSpec.describe Platform::UserFilestoreAdapter do
       end
 
       it 'makes a request to filestore' do
-        adapter.call
-        expect(WebMock).to have_requested(
-          :post, expected_url
-        ).with(headers: expected_headers, body: payload)
-         .once
-      end
-    end
-
-    context 'when there is no user_id in the session' do
-      let(:session) do
-        { session_id: 'two-han-solos-singing-becomes-a-han-duet' }
-      end
-      let(:expected_url) do
-        "#{root_url}/service/#{service_slug}/user/#{session[:session_id]}"
-      end
-
-      it 'makes a request to filestore fallback to the session_id' do
         adapter.call
         expect(WebMock).to have_requested(
           :post, expected_url

--- a/spec/services/platform/user_filestore_payload_spec.rb
+++ b/spec/services/platform/user_filestore_payload_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Platform::UserFilestorePayload do
   end
   let(:session) do
     {
-      session_id: '04cf476c2dd02e01304d7ab321764096',
+      user_id: '04cf476c2dd02e01304d7ab321764096',
       user_token: '162738e2772348798c657c64c226042e'
     }
   end


### PR DESCRIPTION
Now the session id that is generated by rails is not being used
to communicate with the datastore, filestore and submitter.

Using the generated user id instead.

See #378 and #380 for more details.