### PR TITLE
Bump metadata presenter gem 2.3.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.7.0'
-gem 'metadata_presenter', '2.3.4'
+gem 'metadata_presenter', '2.3.5'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.4'
 gem 'rails', '~> 6.1.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.3.4)
+    metadata_presenter (2.3.5)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -340,7 +340,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.7.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.3.4)
+  metadata_presenter (= 2.3.5)
   prometheus-client (~> 2.1.0)
   puma (~> 5.4)
   rails (~> 6.1.4)


### PR DESCRIPTION
Bump to metadata presenter gem v2.3.5
- Fixes spacing on 'check your answers' page

Relates to [PR](https://github.com/ministryofjustice/fb-metadata-presenter/pull/173)