### PR TITLE
Update browser tools orb and install all browser tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  browser-tools: circleci/browser-tools@1.1.3
+  browser-tools: circleci/browser-tools@1.2.1
 
 jobs:
   test:
@@ -76,8 +76,12 @@ jobs:
     docker:
       - image: 'cimg/ruby:2.7-node'
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools
+      - run:
+          name: Check browser tools install
+          command: |
+            google-chrome --version
+            chromedriver --version
       - run:
           name: Run acceptance tests
           environment:


### PR DESCRIPTION
Swap to install all the browser tools as install-chrome by itself is
broken.

There is an open PR to resolve this issue. In the meantime just install
all the things.

CircleCI-Public/browser-tools-orb#33