### PR TITLE
Fix Faraday authorization deprecation warning

### DIFF
--- a/app/services/platform/connection.rb
+++ b/app/services/platform/connection.rb
@@ -20,7 +20,7 @@ module Platform
         conn.options[:timeout] = timeout
 
         # Submitter uses the v3 access token from service token cache
-        conn.authorization :Bearer, service_access_token
+        conn.request :authorization, 'Bearer', service_access_token
       end
     end
 


### PR DESCRIPTION
Bearer token authorization is now a paramter to the request method