### PR TITLE
Do not pin Node version in Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.11
       - run:
           name: Setup containers
           command: make setup-ci
@@ -38,7 +38,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.11
       - add_ssh_keys: &ssh_keys
           fingerprints:
             - "af:e3:71:5e:fc:fd:08:e1:61:d4:18:10:cd:6b:6d:aa"
@@ -101,7 +101,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.11
       - add_ssh_keys: *ssh_keys
       - run: *base_environment_variables
       - run: *deploy_scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG UID=1001
 
 RUN apk add --update yarn build-base bash libcurl git tzdata
 
-RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs=14.18.1-r0 npm
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/main/ nodejs npm
 
 # For load testing
 # Copy Go and install Vegeta

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # README
 
 ## Setup
-Ensure you are running on Node version 14.18.1:
-`nvm use 14.18.1`
+Ensure you are running Node version 14.19.0 LTS. Easiest is to install [NVM](https://github.com/nvm-sh/nvm#installing-and-updating) and then:
+`nvm install 14.19.0`
+`nvm use 14.19.0`
 
 To run the project locally, execute the following steps:
 - Install Ruby dependencies: `bundle install`

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fb_runner",
   "private": true,
   "engines" : {
-    "node" : "14.18.1"
+    "node" : ">=14.19.0"
   },
   "dependencies": {
     "@rails/ujs": "^7.0.1",


### PR DESCRIPTION
With Alpine 3.13 calling apk add and passing `nodejs` by itself will
grab Node version 14.19.0 as of time of writing.

Also use Docker 20.10.11 in the CircleCI config