### PR TITLE
Reduce dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,11 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
-  allow:
-    - dependency-type: all
   reviewers:
   - brenetic
   - mattempty
   - njseeto
+  - chrispymm
 - package-ecosystem: docker
   directory: "/"
   schedule:
@@ -24,6 +23,7 @@ updates:
   - brenetic
   - mattempty
   - njseeto
+  - chrispymm
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -31,9 +31,8 @@ updates:
     time: "03:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
-  allow:
-    - dependency-type: all
   reviewers:
   - mattempty
   - brenetic
   - njseeto
+  - chrispymm


### PR DESCRIPTION
Set the dependebot config back to its default. This will only update
direct dependencies now. There are too many PRs that we cannot get
through.

Also add chris as a reviewer.