### PR TITLE
Use Metadata Presenter 2.16.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.16.9'
+gem 'metadata_presenter', '2.16.10'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.6'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.16.9)
+    metadata_presenter (2.16.10)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -344,7 +344,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.16.9)
+  metadata_presenter (= 2.16.10)
   prometheus-client (~> 2.1.0)
   puma (~> 5.6)
   rails (>= 6.1.4.6)


### PR DESCRIPTION
Includes the fix for checking minimum and maximum validations are in
fact a number.