### PR TITLE
Allow rejecting of non essential cookies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.16.12'
+gem 'metadata_presenter', '2.16.14'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.6'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.16.12)
+    metadata_presenter (2.16.14)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -344,7 +344,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.16.12)
+  metadata_presenter (= 2.16.14)
   prometheus-client (~> 2.1.0)
   puma (~> 5.6)
   rails (>= 6.1.4.6)

--- a/app/javascript/packs/analytics.js
+++ b/app/javascript/packs/analytics.js
@@ -1,0 +1,54 @@
+function accept (cookieName) {
+  setAnalyticsCookie(cookieName, 'accepted')
+  hideCookieMessage()
+  showMessage('accepted')
+}
+
+function reject (cookieName) {
+  setAnalyticsCookie(cookieName, 'rejected')
+  removeAnalyticsCookies()
+  hideCookieMessage()
+  showMessage('rejected')
+}
+
+function setAnalyticsCookie (cookieName, cookieValue) {
+  document.cookie = `${cookieName}=${cookieValue}; expires=${new Date(
+    new Date().getTime() + 1000 * 60 * 60 * 24 * 365
+  ).toUTCString()}; path=/`
+}
+
+function hideCookieMessage () {
+  document.getElementById('govuk-cookie-banner-message').style.display = 'none'
+}
+
+function showMessage (messageType) {
+  document.getElementById(`govuk-cookie-banner-message-${messageType}`).style.display = 'block'
+}
+
+function hideCookieBanner () {
+  document.getElementById('govuk-cookie-banner').style.display = 'none'
+}
+
+function removeAnalyticsCookies () {
+  const cookiePrefixes = ['_ga', '_gid', '_gat_gtag_', '_hj', '_utma', '_utmb', '_utmc', '_utmz']
+  for (const cookie of document.cookie.split(';')) {
+    for (const cookiePrefix of cookiePrefixes) {
+      const cookieName = cookie.split('=')[0].trim()
+      if (cookieName.startsWith(cookiePrefix)) {
+        deleteCookie(cookieName)
+      }
+    }
+  }
+}
+
+function deleteCookie (cookieName) {
+  document.cookie = `${cookieName}=; Path=/; Domain=${location.hostname}; Expires=Thu, 01 Jan 1970 00:00:01 UTC;`
+  document.cookie = `${cookieName}=; Path=/; Domain=.justice.gov.uk; Expires=Thu, 01 Jan 1970 00:00:01 UTC;`
+}
+
+module.exports = {
+  accept: accept,
+  reject: reject,
+  hideCookieBanner: hideCookieBanner,
+  removeAnalyticsCookies: removeAnalyticsCookies
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,6 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
+window.analytics = require("packs/analytics")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference


### PR DESCRIPTION
This adds the functionality which allows users to interact with the
cookie banner. They can accept or reject analytics cookies which in turn
sets another essential cookie identifying their choice.

The metadata presenter had the necessary bits added in [this PR](https://github.com/ministryofjustice/fb-metadata-presenter/pull/242)

<img width="1001" alt="Screenshot 2022-06-07 at 15 45 50" src="https://user-images.githubusercontent.com/3466862/172450929-66a699ea-1262-4a63-b950-7d1eabce9f60.png">

![Screenshot 2022-06-07 at 18 59 47](https://user-images.githubusercontent.com/3466862/172451210-2eb0d797-d8a0-442a-8b1e-c9cd95db45e4.png)

![Screenshot 2022-06-07 at 19 00 06](https://user-images.githubusercontent.com/3466862/172451218-fd5d2427-2900-46c9-a1de-c3799fb627fe.png)