### PR TITLE
Enable MoJ Forms GA4 in Test

### DIFF
--- a/config/initializers/global_analytics.rb
+++ b/config/initializers/global_analytics.rb
@@ -1,0 +1,3 @@
+if ENV['PLATFORM_ENV'] == 'test' && ENV['DEPLOYMENT_ENV'] == 'dev'
+  Rails.application.config.global_ga4 = 'G-H2X4P7GXNR'
+end


### PR DESCRIPTION
This adds the MoJ Forms GA4 measurement ID to an initialiser but only
for the Test environment currently.

The Presenter looks for the existence of this and will then inject the
correct analytics scripts into the head.

We are setting this in an initialiser instead of as an environment
variable as we want to be able to roll this change out to all currently
published runners without the need for republishing.
