### PR TITLE
Remove form from search engines and new mime types for file upload

### DIFF
--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -15,9 +15,11 @@ module Platform
       application/vnd.oasis.opendocument.text
       application/pdf
       application/rtf
+      application/csv
       image/jpeg
       image/png
       application/vnd.ms-excel
+      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
     ].freeze
     MAX_FILE_SIZE = 7_340_032
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
1. Adding robots.txt as a method to ask search engines not to index
the site/ form.
2. Added new mime type for csv created using MS Excel for file uploads
3. Added new mime type for xlsx for file uploads

https://trello.com/c/ZkbTlJVt
https://trello.com/c/G54E7g7R