### PR TITLE
Add `items_present?` method in app controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,6 +63,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :editable?
 
+  def items_present?
+    false
+  end
+  helper_method :items_present?
+
   def answer_params
     params.permit(answers: {})[:answers] || {}
   end


### PR DESCRIPTION
This method is used to check if an autocomplete component has any items already uploaded. It is used on the views in the editor and metadata presenter.