### PR TITLE
Add the ability to send CSV of user answers as an attachment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'simplecov-console'
   gem 'site_prism'
+  gem 'timecop'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,7 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
     tilt (2.0.10)
+    timecop (0.9.5)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
@@ -360,6 +361,7 @@ DEPENDENCIES
   site_prism
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   web-console (>= 3.3.0)
   webmock
   webpacker (~> 5.4)


### PR DESCRIPTION
Setting `SERVICE_CSV_OUTPUT` to 'true' (or just having it present) in
the form container means that an additional action will be added to the
payload that is sent to the Submitter.

The Submitter will then action that and convert the user answers into a
CSV and then attach it to a separate email to the form owner.