### PR TITLE
2727 global analytics 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.17.8'
+gem 'metadata_presenter', '2.17.9'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.6'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.8)
+    metadata_presenter (2.17.9)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -345,7 +345,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.17.8)
+  metadata_presenter (= 2.17.9)
   prometheus-client (~> 2.1.0)
   puma (~> 5.6)
   rails (>= 6.1.4.6)

--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -1,0 +1,14 @@
+// This file is automatically compiled by Webpack, along with any other files
+// present in this directory. You're encouraged to place your actual application logic in
+// a relevant structure within app/javascript and only use these pack files to reference
+// that code so it'll be compiled.
+
+require("@rails/ujs").start()
+window.analytics = require("packs/analytics")
+
+// Uncomment to copy all static images under ../images to the output folder and reference
+// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
+// or the `imagePath` JavaScript helper below.
+//
+// const images = require.context('../images', true)
+// const imagePath = (name) => images(name, true)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title><%= service.service_name %></title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="robots" content="noindex">
+  <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="<%= asset_pack_url('media/images/favicon.ico') %>" type="image/x-icon" />
+  <link rel="mask-icon" href="<%= asset_pack_url('media/images/govuk-mask-icon.svg') %>" color="blue">
+  <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-180x180.png') %>">
+  <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-167x167.png') %>">
+  <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon-152x152.png') %>">
+  <link rel="apple-touch-icon" href="<%= asset_pack_url('media/images/govuk-apple-touch-icon.png') %>">
+
+    <%= stylesheet_pack_tag 'govuk' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+
+    <% if allow_analytics? %>
+      <%= render template: 'metadata_presenter/analytics/analytics' %>
+    <% end %>
+  </head>
+
+  <body class="govuk-template__body">
+    <% if show_cookie_banner? %>
+      <%= render partial: 'metadata_presenter/analytics/cookie_banner' %>
+    <% end %>
+
+    <%= render template: 'metadata_presenter/header/show' %>
+    <div class="govuk-width-container govuk-body-m">
+      <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+      <% if back_link.present? %>
+        <a class="govuk-back-link" href="<%= back_link %>">Back</a>
+      <% end %>
+
+        <%= yield %>
+      </main>
+    </div>
+    <%= render template: 'metadata_presenter/footer/footer' %>
+    <%= javascript_pack_tag 'runner_application' %>
+    <%= javascript_pack_tag 'govuk' %>
+  </body>
+</html>

--- a/spec/features/exit_pages_spec.rb
+++ b/spec/features/exit_pages_spec.rb
@@ -81,7 +81,8 @@ RSpec.feature 'Exit pages' do
   end
 
   def and_I_should_not_see_a_continue_button
-    expect(page).not_to have_selector('.govuk-button')
+    expect(page).to have_selector('#new_answers')
+    expect(page).not_to have_selector('#new_answers .govuk-button')
   end
 
   def then_I_should_be_on_check_your_answers_page


### PR DESCRIPTION
https://trello.com/c/h3595yEp/2727-show-cookie-banner-when-global-analytics-is-configured-for-a-form

Pulls in latest from Metadata Presenter for Analytics handling

(Replaces previous PR https://github.com/ministryofjustice/fb-runner/pull/970 with clean commit history)