### PR TITLE
Convert checkbox component answers to semi colon separated string

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -153,7 +153,7 @@ module Platform
     end
 
     def checkboxes(answer)
-      answer.to_a
+      answer.to_a.join('; ')
     end
 
     def upload(answer)

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             field_id: 'burgers_checkboxes_1',
             field_name: 'What would you like on your burger?',
-            answer: ['Beef, cheese, tomato', 'Chicken, cheese, tomato']
+            answer: 'Beef, cheese, tomato; Chicken, cheese, tomato'
           }
         ]
       },
@@ -296,17 +296,19 @@ RSpec.describe Platform::SubmitterPayload do
           { heading: '',
             answers: [{ field_id: 'burgers_checkboxes_1',
                         field_name: 'What would you like on your burger?',
-                        answer: ['Mozzarella, cheddar, feta'] }] },
+                        answer: 'Mozzarella, cheddar, feta' }] },
           { heading: '',
             answers: [{ field_id: 'marvel-series_radios_1',
                         field_name: 'What is the best marvel series?',
                         answer: 'Loki' }] },
           { heading: '',
-            answers: [{ field_id: 'best-arnold-quote_checkboxes_1',
-                        field_name: 'Select all Arnold Schwarzenegger quotes',
-                        answer: ['You are not you. You are me',
-                                 'Get to the chopper',
-                                 'You have been terminated'] }] }
+            answers: [
+              {
+                field_id: 'best-arnold-quote_checkboxes_1',
+                field_name: 'Select all Arnold Schwarzenegger quotes',
+                answer: 'You are not you. You are me; Get to the chopper; You have been terminated'
+              }
+            ] }
         ]
       end
 
@@ -358,7 +360,7 @@ RSpec.describe Platform::SubmitterPayload do
         ).to eq({
           field_id: 'burgers_checkboxes_1',
           field_name: 'What would you like on your burger?',
-          answer: []
+          answer: ''
         })
       end
 


### PR DESCRIPTION
Previously checkbox answers were just an array of the different options
when submitted. e.g

['beef, cheese, tomato', 'chicken, tomato, lettuce']

This changes the answers to take the form:

'beef, cheese, tomato; chicken, tomato, lettuce'

The answers are concatenated into a string and separated by a semi
colon.

This changes the output for both the PDF file of the answers and the CSV
attachment generated by the submitter.

Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>