### PR TITLE
Reinstate CSS used to tweak background color and content height

### DIFF
--- a/app/javascript/styles/govuk.scss
+++ b/app/javascript/styles/govuk.scss
@@ -18,3 +18,13 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 .autocomplete__wrapper {
   z-index: 0;
 }
+
+// Enables the footer color to go to the base of the window
+// and forces min height of content area
+html {
+  background-color: #F3F2F1;
+}
+
+#main-content {
+  min-height: 55vh;
+}


### PR DESCRIPTION
Quick fix to reinstate a few lines of css that set the html background color and force a min-height on the main content area.

These got accidentally when the assets were refactored slightly a few days back.