### PR TITLE
Allow global_ga4 on live

### DIFF
--- a/config/initializers/global_analytics.rb
+++ b/config/initializers/global_analytics.rb
@@ -1,3 +1,1 @@
-if ENV['PLATFORM_ENV'] == 'test' && ENV['DEPLOYMENT_ENV'] == 'dev'
-  Rails.application.config.global_ga4 = 'G-H2X4P7GXNR'
-end
+Rails.application.config.global_ga4 = 'G-H2X4P7GXNR'


### PR DESCRIPTION
Remove the condition that is preventing Global Analytics from appearing on Live Runner.