### PR TITLE
Update locales from presenter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.17.19'
+gem 'metadata_presenter', '2.17.20'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.6'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.19)
+    metadata_presenter (2.17.20)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -343,7 +343,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.17.19)
+  metadata_presenter (= 2.17.20)
   prometheus-client (~> 2.1.0)
   puma (~> 5.6)
   rails (>= 6.1.4.6)

--- a/spec/support/pages/branching_fixture.rb
+++ b/spec/support/pages/branching_fixture.rb
@@ -3,7 +3,7 @@ class BranchingFixture < SitePrism::Page
 
   set_url '/'
   element :heading, 'h1'
-  element :start_button, :button, I18n.t('actions.start')
+  element :start_button, :button, I18n.t('presenter.actions.start')
   element :full_name_field, :field, 'Full name'
   element :star_wars_only_on_weekends, :radio_button, 'Only on weekends'
   element :star_wars_hell_no, :radio_button, 'Hell no!'
@@ -21,9 +21,9 @@ class BranchingFixture < SitePrism::Page
   element :falcon, :radio_button, 'The Falcon and the Winter Soldier'
   element :wandavision, :radio_button, 'WandaVision'
   element :back_link, :link, 'Back'
-  element :continue_button, :button, I18n.t('actions.continue')
+  element :continue_button, :button, I18n.t('presenter.actions.continue')
   elements :summary_list, '.govuk-summary-list__row'
-  element :accept_and_send_button, :button, I18n.t('actions.submit')
+  element :accept_and_send_button, :button, I18n.t('presenter.actions.submit')
   element :confirmation_heading, '.govuk-panel__title'
   data_content_id :confirmation_lede, 'page[lede]'
   data_content_id :confirmation_body, 'page[body]'

--- a/spec/support/pages/exit_pages.rb
+++ b/spec/support/pages/exit_pages.rb
@@ -2,7 +2,7 @@ class ExitPagesFixture < SitePrism::Page
   extend DataContentId
 
   set_url '/'
-  element :start_button, :button, I18n.t('actions.start')
+  element :start_button, :button, I18n.t('presenter.actions.start')
   element :page_b_field, :field, 'Page B'
   element :page_c_field, :field, 'Page C'
   element :page_i_field, :field, 'Page I'
@@ -10,7 +10,7 @@ class ExitPagesFixture < SitePrism::Page
   element :page_l_field, :field, 'Page L'
   element :page_knowhere_field, :field, 'Road to knowhere'
   element :page_ghost_field, :field, 'Ghost town'
-  element :continue_button, :button, I18n.t('actions.continue')
+  element :continue_button, :button, I18n.t('presenter.actions.continue')
   element :item_3, :radio_button, 'Item 3'
   element :item_2, :radio_button, 'Item 2'
   element :back_link, :link, 'Back'

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -3,8 +3,8 @@ class VersionFixture < SitePrism::Page
 
   set_url '/'
   element :heading, 'h1'
-  element :start_button, :button, I18n.t('actions.start')
-  element :continue_button, :button, I18n.t('actions.continue')
+  element :start_button, :button, I18n.t('presenter.actions.start')
+  element :continue_button, :button, I18n.t('presenter.actions.continue')
   element :full_name_field, :field, 'Full name'
   element :parent_field, :field, 'Parent name'
   element :email_field, :field, 'Email address'
@@ -26,7 +26,7 @@ class VersionFixture < SitePrism::Page
   elements :error_summary_list, '.govuk-error-summary__list'
   elements :inline_error_messages, '.govuk-error-message'
   elements :summary_list, '.govuk-summary-list__row'
-  element :accept_and_send_button, :button, I18n.t('actions.submit')
+  element :accept_and_send_button, :button, I18n.t('presenter.actions.submit')
   element :confirmation_heading, '.govuk-panel__title'
   data_content_id :confirmation_lede, 'page[lede]'
   data_content_id :confirmation_body, 'page[body]'


### PR DESCRIPTION
[Trello](https://trello.com/c/TXA2riSt/2854-update-new-service-generator-to-use-cookies-content-from-the-presenter)

We have changed the presenter locales to have the presenter property.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>