### PR TITLE
Mirrored action on Editor for sharing Content (and improving Analytics)

### DIFF
--- a/app/javascript/packs/runner_application.js
+++ b/app/javascript/packs/runner_application.js
@@ -4,9 +4,15 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
+require("../src/runner/contentloaded.js")
+require("../src/runner/analytics")
+require("../src/runner/index")
+
+// Entry point for fb-editor stylesheets
+import "../styles/application.scss"
 
 const accessibleAutocomplete = require("accessible-autocomplete")
-import 'accessible-autocomplete/dist/accessible-autocomplete.min.css' 
+import 'accessible-autocomplete/dist/accessible-autocomplete.min.css'
 
 // Initialise autocomplete components
 const autocompleteElements = document.querySelectorAll('.fb-autocomplete');
@@ -47,7 +53,6 @@ if(autocompleteComponent) {
   });
 }
 
-window.analytics = require("../src/analytics")
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
@@ -55,3 +60,4 @@ window.analytics = require("../src/analytics")
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
+

--- a/app/javascript/src/runner/analytics.js
+++ b/app/javascript/src/runner/analytics.js
@@ -46,9 +46,14 @@ function deleteCookie (cookieName) {
   document.cookie = `${cookieName}=; Path=/; Domain=.justice.gov.uk; Expires=Thu, 01 Jan 1970 00:00:01 UTC;`
 }
 
-module.exports = {
+
+// So we can just access required functions from the window object
+window.analytics = {
   accept: accept,
   reject: reject,
   hideCookieBanner: hideCookieBanner,
   removeAnalyticsCookies: removeAnalyticsCookies
 }
+
+// In case we want to require it like a module
+module.exports = window.analytics;

--- a/app/javascript/src/runner/contentloaded.js
+++ b/app/javascript/src/runner/contentloaded.js
@@ -1,0 +1,6 @@
+/*! contentloaded.min.js - https://github.com/dperini/ContentLoaded - Author: Diego Perini - License: MIT */
+function contentLoaded(b,i){var j=false,k=true,a=b.document,l=a.documentElement,f=a.addEventListener,h=f?'addEventListener':'attachEvent',n=f?'removeEventListener':'detachEvent',g=f?'':'on',c=function(d){if(d.type=='readystatechange'&&a.readyState!='complete')return;(d.type=='load'?b:a)[n](g+d.type,c,false);if(!j&&(j=true))i.call(b,d.type||d)},m=function(){try{l.doScroll('left')}catch(e){setTimeout(m,50);return}c('poll')};if(a.readyState=='complete')i.call(b,'lazy');else{if(!f&&l.doScroll){try{k=!b.frameElement}catch(e){}if(k)m()}a[h](g+'DOMContentLoaded',c,false);a[h](g+'readystatechange',c,false);b[h](g+'load',c,false)}}
+
+
+// fb-runner addition
+window.contentLoaded = contentLoaded;

--- a/app/javascript/src/runner/index.js
+++ b/app/javascript/src/runner/index.js
@@ -1,0 +1,48 @@
+const {
+  htmlAdjustment,
+  markdownAdjustment
+} = require('../shared/content');
+
+const ENVIRONMENT_PREVIEW = "preview";
+const ENVIRONMENT_RUNNER = "runner";
+
+
+/* Discover what environment we're playing in by checking the URL
+ **/
+function environment() {
+  return location.pathname.search(/^\/services\/.*?\/preview\/$/) >= 0 ? ENVIRONMENT_PREVIEW : ENVIRONMENT_RUNNER;
+}
+
+
+/* Stop cookie banner from showing in preview mode.
+ * We don't need cookie or analytics related warnings
+ * in the preview.
+ **/
+function preventCookieBannerInPreview() {
+  var cookieBanner = document.getElementById("govuk-cookie-banner");
+  if(cookieBanner && environment() ==  ENVIRONMENT_PREVIEW) {
+    cookieBanner.style.display = "none";
+  }
+}
+
+
+/* Enhances the edited content should it require special formatting
+ * or non-standard elements.
+ * e.g.
+ *  - Adds GovUk classes to any <table> element
+ *  - Changes supported GovSpeak markup to required HTML.
+ **/
+function supportGovUkContent() {
+  var content = document.querySelectorAll("[data-fb-content-type=content]");
+  for( var c=0; c<content.length; ++c) {
+    content[c].innerHTML = htmlAdjustment(content[c].innerHTML);
+  }
+}
+
+
+/* Page initialiser section
+ **/
+contentLoaded(window, () => {
+  preventCookieBannerInPreview();
+  supportGovUkContent();
+});

--- a/app/javascript/src/shared/content.js
+++ b/app/javascript/src/shared/content.js
@@ -1,0 +1,89 @@
+
+/* Adjust the HTML output before it is shown.
+ * This won't affect the stored markdown but it should allow the presented
+ * HTML reflect the required visual design.
+ **/
+function htmlAdjustment(html) {
+  html = supportGovUKTableCSS(html);
+  html = supportGovSpeakCtaMarkup(html);
+  return html;
+}
+
+
+/* Adjust the HTML output before it is shown.
+ * This won't affect the stored markdown but it should allow the presented
+ * HTML reflect the required visual design.
+ **/
+function markdownAdjustment(markdown) {
+  return supportGovSpeakCtaMarkup(markdown);
+}
+
+
+/* Since markdown does not support class name application (without third-party
+ * scripts), and GovUK CSS requires a horrendous amount of class names to pull
+ * inbtheir preferred CSS style, we're making JS controlled adjustments to the
+ * converted (markdown to html) markup. The alternative would be to replicate
+ * GovUK CSS to which could be applied to <table> elements withing content.
+ **/
+function supportGovUKTableCSS(html) {
+  html = html.replace(/<table>/mig, "<table class=\"govuk-table\">");
+  html = html.replace(/<thead>/mig, "<thead class=\"govuk-table__head\">");
+  html = html.replace(/<tbody>/mig, "<tbody class=\"govuk-table__body\">");
+  html = html.replace(/<tr>/mig, "<tr class=\"govuk-table__row\">");
+  html = html.replace(/<th>/mig, "<th class=\"govuk-table__header\">");
+  html = html.replace(/<td>/mig, "<td class=\"govuk-table__cell\">");
+  return html;
+}
+
+
+/* Since there is no HTML 'call to action' element, markdown does not support
+ * any syntax that can produce such output. The GovSpeak project does provide
+ * some conversion to produce a visual output, coupled with CSS, that can act
+ * as a CTA component. We do not support GovSpeak so this function uses the
+ * same expected 'markdown' syntax and converts into the same HTML output that
+ * GovSpeak would generate (separate CSS needs to be applied).
+ *
+ * @content (String) Either markdown or html
+ *
+ * ---------------------------------------------------------------------------
+ *
+ * 1. If we're passing HTML then we expect
+ *       <p>$cta something like this $cta </p>
+ *
+ *    and want to turn it into
+ *       <div class=\"call-to-action\"><p>something like this</p></div>
+ *
+ *    This is the markup used by GovSpeak for CTA elements.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * 2. If we're passing markdown then we expect
+ *       $cta something like this $cta
+ *
+ *    and want to turn it into
+ *       $cta
+ *       something like this
+ *       $cta
+ *
+ *    The line-breaks, even if stored, get obliterated by the markdown converter
+ *    so that is why we're having to put them back.
+ *
+ * ----------------------------------------------------------------------------
+ *
+ * NOTE: Case insensitive - either $cta or $CTA or $cTa, etc.
+ *
+ **/
+function supportGovSpeakCtaMarkup(content) {
+  // 1.
+  content = content.replace(/<p>\$cta\n?(.*)?\n?\$cta<\/p>/mig, "<div class=\"call-to-action\"><p>$1</p></div>");
+  // 2.
+  content = content.replace(/\$cta It looks like this. \$cta/, "$cta\nIt looks like this.\n$cta");
+  return content;
+}
+
+
+
+module.exports = {
+  htmlAdjustment: htmlAdjustment,
+  markdownAdjustment: markdownAdjustment
+}

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -1,0 +1,18 @@
+/*
+ * This is a manifest file that'll be compiled into application.css, which will include all the files
+ * listed below.
+ *
+ * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
+ * vendor/assets/stylesheets directory can be referenced here using a relative path.
+ *
+ * You're free to add application-wide styles to this file and they'll appear at the bottom of the
+ * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
+ * files in this directory. Styles in this file should be added after the last require_* statement.
+ * It is generally better to create a new file per style scope.
+ *
+ *= require_tree .
+ *= require_self
+ */
+
+@import "govuk-frontend/govuk/helpers/colour";
+@import "./shared/content";

--- a/app/javascript/styles/shared/_content.scss
+++ b/app/javascript/styles/shared/_content.scss
@@ -1,0 +1,12 @@
+
+/* Emulate GovSpeak styles
+ * -------------------------------- */
+.call-to-action {
+  background-color: govuk-colour("light-grey");
+  margin: 2em 0;
+  padding: 2em
+}
+
+.call-to-action > p {
+  margin: 0;
+}


### PR DESCRIPTION
- Add conversion adaptor to allow GovUK styled `<table>`
- Add fix for broken `<blockquote>` markdown -> html
- Add conversion adaptor to emulate GovSpeak `$CTA` elements.

All can be seen here:
<img width="690" alt="Screenshot 2022-09-07 at 14 35 36" src="https://user-images.githubusercontent.com/76942244/188892110-7f92a100-32bf-4bf3-bc3a-dbf11795b7ae.png">

For more information, see https://github.com/ministryofjustice/fb-editor/pull/1738