### PR TITLE
Unpin Docker version in CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker: &remote_docker
-          version: 20.10.11
           docker_layer_caching: true
       - run: &base_environment_variables
           name: Setup base environment variable


### PR DESCRIPTION
CircleCI will keep the Docker executor up to date on a rolling basis.

### Checklist:
 - [x] [CircleCI run](https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner/5274/workflows/1cf62035-2781-4ae1-a738-b482cda77daa) 🟢 
 - [x] Check the services pods are running in Test Dev and Test prod in Lens
 - [x] Check we can still preview forms in Test
 - [x] Check we can access forms in Test and Live when published via Test Editor (test-dev and test-prod environments)