### PR TITLE
Add ability to send a confirmation email of users answers

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -14,6 +14,9 @@ SERVICE_EMAIL_PDF_SUBHEADING='Sub Heading'
 SERVICE_EMAIL_FROM="form-builder-developers@digital.justice.gov.uk"
 SERVICE_EMAIL_SUBJECT="Subject"
 SERVICE_EMAIL_BODY="Email body"
+CONFIRMATION_EMAIL_SUBJECT="Confirmation email subject"
+CONFIRMATION_EMAIL_BODY="Confirmation email body"
+CONFIRMATION_EMAIL_COMPONENT_ID="email-address_email_1"
 
 # Details from the fb-acceptance-tests-repo
 SUBMISSION_ENCRYPTION_KEY='52905141-4738-4cce-8bd6-633c970c'

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -39,7 +39,7 @@ module Platform
     end
 
     def actions
-      [email_action, csv_action].compact
+      [email_action, csv_action, confirmation_email_action].compact
     end
 
     def pages
@@ -119,6 +119,20 @@ module Platform
       }
     end
 
+    def confirmation_email_action
+      return if confirmation_email_answer.blank?
+
+      {
+        kind: EMAIL,
+        to: confirmation_email_answer,
+        from: ENV['SERVICE_EMAIL_FROM'],
+        subject: ENV['CONFIRMATION_EMAIL_SUBJECT'],
+        email_body: ENV['CONFIRMATION_EMAIL_BODY'],
+        include_attachments: true,
+        include_pdf: true
+      }
+    end
+
     def strip_content_components(components)
       return [] if components.blank?
 
@@ -164,6 +178,10 @@ module Platform
       return '' if answer.blank?
 
       JSON.parse(answer)['value']
+    end
+
+    def confirmation_email_answer
+      @confirmation_email_answer ||= user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]
     end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/bYkpFQj9/3027-confirmation-email-06-runner-use-the-collected-email-address-to-send-the-confirmation-email)

### Add ability to send a confirmation email of users answers
The confirmation email feature requires the user's answer to an email component to work. Therefore, we need to add a new action that pulls out the user's answer from the correct email component, this is identified by the 'CONFIRMATION_EMAIL_COMPONENT_ID'.

The presence of a 'CONFIRMATION_EMAIL_COMPONENT_ID' will add the action to the payload that is sent to the Submitter. The Submitter then actions this, sending a copy of the user's answers to the email address provided by the email component.

Since, it is possible for a form editor to choose an email component that is optional, we need to ensure we the submitter does not attempt to send an email if there is no email provided - for example, when the email component chosen is an optional question.

### Add env vars for local development
The env vars are largely self explanatory, except the `CONFIRMATION_EMAIL_COMPONENT_ID` which defaults to the email component that is present on the `version.json` fixture.