### PR TITLE
Download metadata from S3 on startup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.7.6'
 
+gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'faraday'
 gem 'faraday_middleware'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,22 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ansi (1.5.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.655.0)
+    aws-sdk-core (3.166.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.59.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.117.1)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     bootsnap (1.13.0)
       msgpack (~> 1.2)
@@ -132,6 +148,7 @@ GEM
       activesupport (>= 6.1.4.4)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    jmespath (1.6.1)
     json (2.6.2)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -333,6 +350,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap (>= 1.4.2)
   brakeman
   byebug

--- a/app/services/aws_s3_client.rb
+++ b/app/services/aws_s3_client.rb
@@ -1,0 +1,20 @@
+require 'aws-sdk-s3'
+
+class AwsS3Client
+  REGION = 'eu-west-2'.freeze
+
+  def get_object(object_key)
+    response = s3.get_object(bucket: ENV['BUCKET_NAME'], key: object_key)
+    response.body.read
+  end
+
+  private
+
+  def s3
+    @s3 ||= Aws::S3::Client.new(region: REGION, credentials: credentials)
+  end
+
+  def credentials
+    Aws::Credentials.new(ENV['ACCESS_KEY_ID'], ENV['SECRET_ACCESS_KEY'])
+  end
+end

--- a/app/services/load_service_metadata.rb
+++ b/app/services/load_service_metadata.rb
@@ -1,35 +1,48 @@
+require 'fileutils'
+
 class LoadServiceMetadata
   class ServiceMetadataNotFoundError < StandardError
   end
 
-  def initialize(service_metadata:, fixture:, asset_precompile:)
+  include MetadataFiles
+
+  def initialize(service_id:, service_metadata:, fixture:, asset_precompile:)
+    @service_id = service_id
     @service_metadata = service_metadata
     @fixture = MetadataPresenter::Engine.root.join('fixtures', "#{fixture}.json")
     @asset_precompile = asset_precompile
   end
 
+  METADATA_FILE = 'metadata.json'.freeze
+
   def to_h
-    if metadata_to_load && valid_metadata?
-      return metadata_to_load
-    end
+    metadata = metadata_to_load
+    return metadata if metadata.present? && valid_metadata?(metadata)
 
     raise ServiceMetadataNotFoundError, error_message if @asset_precompile.blank?
   end
 
   def metadata_to_load
-    @_metadata_to_load ||= begin
-      if @service_metadata.blank? && File.exist?(@fixture)
-        puts("Loading fixture #{@fixture}")
-        return JSON.parse(File.read(@fixture))
-      end
+    return download_metadata(object_key) if @service_id.present?
 
-      return JSON.parse(@service_metadata) if @service_metadata.present?
+    if @service_metadata.blank? && File.exist?(@fixture)
+      puts("Loading fixture #{@fixture}")
+      return JSON.parse(File.read(@fixture))
+    end
+
+    if @service_metadata.present?
+      Rails.logger.info('Loading service metadata from environment')
+      JSON.parse(@service_metadata)
     end
   end
 
-  def valid_metadata?
-    MetadataPresenter::ValidateSchema.validate(metadata_to_load, 'service.base')
-    Array(metadata_to_load['pages']).each do |page|
+  def object_key
+    "#{@service_id}_#{METADATA_FILE}"
+  end
+
+  def valid_metadata?(metadata)
+    MetadataPresenter::ValidateSchema.validate(metadata, 'service.base')
+    Array(metadata['pages']).each do |page|
       MetadataPresenter::ValidateSchema.validate(page, page['_type'])
     end
   end

--- a/app/services/metadata_files.rb
+++ b/app/services/metadata_files.rb
@@ -1,0 +1,19 @@
+module MetadataFiles
+  SERVICE_METADATA_DIRECTORY = Rails.root.join('tmp', 'service_metadata').freeze
+
+  def download_metadata(key)
+    FileUtils.mkdir_p(SERVICE_METADATA_DIRECTORY) unless File.exist?(SERVICE_METADATA_DIRECTORY)
+
+    Rails.logger.info("Downloading #{key} from S3")
+    metadata = s3_client.get_object(key)
+    File.write(File.join(SERVICE_METADATA_DIRECTORY, key), metadata)
+    JSON.parse(metadata)
+  rescue Aws::S3::Errors::ServiceError => e
+    Sentry.capture_exception(e)
+    nil
+  end
+
+  def s3_client
+    @s3_client ||= AwsS3Client.new
+  end
+end

--- a/config/initializers/autocomplete_items.rb
+++ b/config/initializers/autocomplete_items.rb
@@ -1,5 +1,6 @@
 Rails.application.reloader.to_prepare do
   Rails.configuration.autocomplete_items = LoadAutocompleteItems.new(
+    service_id: ENV['SERVICE_ID'],
     autocomplete_items: ENV['AUTOCOMPLETE_ITEMS'],
     fixture: ENV['AUTOCOMPLETE_FIXTURE']
   ).to_h

--- a/config/initializers/service_metadata.rb
+++ b/config/initializers/service_metadata.rb
@@ -1,6 +1,7 @@
 Rails.application.reloader.to_prepare do
   begin
     Rails.configuration.service_metadata = LoadServiceMetadata.new(
+      service_id: ENV['SERVICE_ID'],
       service_metadata: ENV['SERVICE_METADATA'],
       fixture: ENV['SERVICE_FIXTURE'],
       asset_precompile: ENV['ASSET_PRECOMPILE']

--- a/spec/services/load_autocomplete_items_spec.rb
+++ b/spec/services/load_autocomplete_items_spec.rb
@@ -1,62 +1,83 @@
 RSpec.describe LoadAutocompleteItems do
   subject(:load_autocomplete_items) { described_class.new(attributes) }
+  let(:service_id) { nil }
+  let(:autocomplete_items) { nil }
+  let(:fixture) { nil }
+  let(:attributes) do
+    {
+      service_id: service_id,
+      autocomplete_items: autocomplete_items,
+      fixture: fixture
+    }
+  end
 
   describe '#to_h' do
-    context 'when there are autocomplete items' do
-      let(:autocomplete_items) do
+    context 'when there is no service id present' do
+      context 'when there are autocomplete items' do
+        let(:autocomplete_items) do
+          File.read(
+            MetadataPresenter::Engine.root.join('fixtures', 'countries.json')
+          )
+        end
+
+        it 'returns the autocomplete items' do
+          expect(load_autocomplete_items.to_h).to eq(JSON.parse(autocomplete_items))
+        end
+      end
+
+      context 'when autocomplete items is blank' do
+        context 'when fixture is present' do
+          let(:fixture) { 'countries' }
+          let(:expected_values) do
+            {
+              '4dc23b9c-9757-4526-813d-b43efbe07dad' =>
+              [
+                { 'text' => 'Afghanistan', 'value' => 'AF' },
+                { 'text' => 'Albania', 'value' => 'AL' },
+                { 'text' => 'Australia', 'value' => 'AU' }
+              ]
+            }
+          end
+
+          it 'returns the autocomplete items from fixture' do
+            expect(load_autocomplete_items.to_h).to include(expected_values)
+          end
+        end
+      end
+
+      context 'when autocomplete items is invalid' do
+        let(:autocomplete_items) { %({ "foo": ["bar"] }) }
+
+        it 'raises JSON schema validation error' do
+          expect {
+            load_autocomplete_items.to_h
+          }.to raise_error(JSON::Schema::ValidationError)
+        end
+      end
+    end
+
+    context 'when there is a service id present' do
+      let(:service_id) { SecureRandom.uuid }
+      let(:file_body) do
         File.read(
           MetadataPresenter::Engine.root.join('fixtures', 'countries.json')
         )
       end
-      let(:attributes) do
-        {
-          autocomplete_items: autocomplete_items,
-          fixture: nil
-        }
+
+      before do
+        allow_any_instance_of(AwsS3Client).to receive(:get_object)
+          .with(load_autocomplete_items.object_key)
+          .and_return(file_body)
       end
 
-      it 'returns the autocomplete items' do
-        expect(load_autocomplete_items.to_h).to eq(JSON.parse(autocomplete_items))
-      end
-    end
-
-    context 'when autocomplete items is blank' do
-      context 'when fixture is present' do
-        let(:attributes) do
-          {
-            autocomplete_items: nil,
-            fixture: 'countries'
-          }
-        end
-        let(:expected_values) do
-          {
-            '4dc23b9c-9757-4526-813d-b43efbe07dad' =>
-            [
-              { 'text' => 'Afghanistan', 'value' => 'AF' },
-              { 'text' => 'Albania', 'value' => 'AL' },
-              { 'text' => 'Australia', 'value' => 'AU' }
-            ]
-          }
-        end
-
-        it 'returns the autocomplete items from fixture' do
-          expect(load_autocomplete_items.to_h).to include(expected_values)
-        end
-      end
-    end
-
-    context 'when autocomplete items is invalid' do
-      let!(:attributes) do
-        {
-          autocomplete_items: %({ "foo": ["bar"] }),
-          fixture: nil
-        }
+      it 'should write the service metadata to file' do
+        file_path = File.join(LoadAutocompleteItems::SERVICE_METADATA_DIRECTORY, load_autocomplete_items.object_key)
+        expect(File).to receive(:write).with(file_path, file_body)
+        load_autocomplete_items.to_h
       end
 
-      it 'raises JSON schema validation error' do
-        expect {
-          load_autocomplete_items.to_h
-        }.to raise_error(JSON::Schema::ValidationError)
+      it 'should return the correct metadata' do
+        expect(load_autocomplete_items.to_h).to eq(JSON.parse(file_body))
       end
     end
   end

--- a/spec/services/load_service_metadata_spec.rb
+++ b/spec/services/load_service_metadata_spec.rb
@@ -2,88 +2,95 @@ RSpec.describe LoadServiceMetadata do
   subject(:load_service_metadata) { described_class.new(attributes) }
 
   describe '#to_h' do
-    context 'when service metadata is present' do
-      let(:service_metadata) do
+    let(:service_id) { nil }
+    let(:service_metadata) { nil }
+    let(:fixture) { nil }
+    let(:asset_precompile) { nil }
+    let(:attributes) do
+      {
+        service_id: service_id,
+        service_metadata: service_metadata,
+        fixture: fixture,
+        asset_precompile: asset_precompile
+      }
+    end
+
+    context 'when there is no service id present' do
+      context 'when service metadata is present' do
+        let(:service_metadata) do
+          File.read(
+            MetadataPresenter::Engine.root.join('fixtures', 'service.json')
+          )
+        end
+
+        it 'returns the service metadata' do
+          expect(load_service_metadata.to_h).to eq(JSON.parse(service_metadata))
+        end
+      end
+
+      context 'when service metadata is blank' do
+        context 'when fixture is present' do
+          let(:fixture) { 'version' }
+
+          it 'returns the service metadata from fixture' do
+            expect(load_service_metadata.to_h).to include(
+              'service_name' => 'Version Fixture'
+            )
+          end
+        end
+
+        context 'when fixture is not present' do
+          context 'when asset pipeline is present' do
+            let(:asset_precompile) { true }
+
+            it 'returns nil' do
+              expect(load_service_metadata.to_h).to be(nil)
+            end
+          end
+
+          context 'when asset pipeline is not present' do
+            it 'returns the service metadata' do
+              expect {
+                load_service_metadata.to_h
+              }.to raise_error(LoadServiceMetadata::ServiceMetadataNotFoundError)
+            end
+          end
+        end
+      end
+
+      context 'when metadata is invalid' do
+        let(:service_metadata) { %({ "service_name": "Luke" }) }
+
+        it 'raises JSON schema validation error' do
+          expect {
+            load_service_metadata.to_h
+          }.to raise_error(JSON::Schema::ValidationError)
+        end
+      end
+    end
+
+    context 'when there is a service id present' do
+      let(:service_id) { SecureRandom.uuid }
+      let(:file_body) do
         File.read(
           MetadataPresenter::Engine.root.join('fixtures', 'service.json')
         )
       end
-      let(:attributes) do
-        {
-          service_metadata: service_metadata,
-          fixture: nil,
-          asset_precompile: nil
-        }
+
+      before do
+        allow_any_instance_of(AwsS3Client).to receive(:get_object)
+          .with(load_service_metadata.object_key)
+          .and_return(file_body)
       end
 
-      it 'returns the service metadata' do
-        expect(load_service_metadata.to_h).to eq(JSON.parse(service_metadata))
-      end
-    end
-
-    context 'when service metadata is blank' do
-      context 'when fixture is present' do
-        let(:attributes) do
-          {
-            service_metadata: nil,
-            fixture: 'version',
-            asset_precompile: nil
-          }
-        end
-
-        it 'returns the service metadata from fixture' do
-          expect(load_service_metadata.to_h).to include(
-            'service_name' => 'Version Fixture'
-          )
-        end
+      it 'should write the service metadata to file' do
+        file_path = File.join(LoadServiceMetadata::SERVICE_METADATA_DIRECTORY, load_service_metadata.object_key)
+        expect(File).to receive(:write).with(file_path, file_body)
+        load_service_metadata.to_h
       end
 
-      context 'when fixture is not present' do
-        context 'when asset pipeline is present' do
-          let(:attributes) do
-            {
-              service_metadata: nil,
-              fixture: nil,
-              asset_precompile: true
-            }
-          end
-
-          it 'returns nil' do
-            expect(load_service_metadata.to_h).to be(nil)
-          end
-        end
-
-        context 'when asset pipeline is not present' do
-          let(:attributes) do
-            {
-              service_metadata: nil,
-              fixture: nil,
-              asset_precompile: nil
-            }
-          end
-
-          it 'returns the service metadata' do
-            expect {
-              load_service_metadata.to_h
-            }.to raise_error(LoadServiceMetadata::ServiceMetadataNotFoundError)
-          end
-        end
-      end
-    end
-
-    context 'when metadata is invalid' do
-      let(:attributes) do
-        {
-          service_metadata: %({ "service_name": "Luke" }),
-          fixture: nil,
-          asset_precompile: nil
-        }
-      end
-
-      it 'raises JSON schema validation error' do
-        expect {
-          load_service_metadata.to_h
-        }.to raise_error(JSON::Schema::ValidationError)
+      it 'should return the correct metadata' do
+        expect(load_service_metadata.to_h).to eq(JSON.parse(file_body))
       end
     end
   end


### PR DESCRIPTION
We now upload the service metadata and autocomplete items as objects to
an S3 bucket. Should there be a SERVICE_ID in the environment of the
form container then make the request to S3 to get the necessary files.

Then load them in much the same way as the current metadata is loaded.

We need to maintain backwards compatability to allow forms already
published to look for metadata in the environment, as well as local
development's use of fixtures