### PR TITLE
Adding the generation of a reference number in the runner at submission

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,6 +17,7 @@ SERVICE_EMAIL_BODY="Email body"
 CONFIRMATION_EMAIL_SUBJECT="Confirmation email subject"
 CONFIRMATION_EMAIL_BODY="Confirmation email body"
 CONFIRMATION_EMAIL_COMPONENT_ID="email-address_email_1"
+REFERENCE_NUMBER=1
 
 # Details from the fb-acceptance-tests-repo
 SUBMISSION_ENCRYPTION_KEY='52905141-4738-4cce-8bd6-633c970c'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include ReferenceNumberHelper
   protect_from_forgery with: :exception
 
   before_action :require_basic_auth
@@ -51,11 +52,16 @@ class ApplicationController < ActionController::Base
   end
 
   def create_submission
+    if ENV['REFERENCE_NUMBER'].present?
+      session['user_data'] = session['user_data'].merge(reference_number)
+    end
+    # rubocop: disable Rails/SaveBang
     Platform::Submission.new(
       service: service,
       user_data: load_user_data,
       session: session
     ).save
+    # rubocop: enable Rails/SaveBang
   end
 
   def editable?
@@ -85,8 +91,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def reference_number_enabled?
-    false
+  def reference_number
+    { 'reference_number' => generate_reference_number }
   end
-  helper_method :reference_number_enabled?
 end

--- a/app/helpers/reference_number_helper.rb
+++ b/app/helpers/reference_number_helper.rb
@@ -1,0 +1,22 @@
+module ReferenceNumberHelper
+  # rubocop :disable Style/MutableConstant
+  RANDOM_SOURCE_SET_1 = 'ABCDEFGHJKLMNPQRSTUVWXYZ'
+  # rubocop :enable Style/MutableConstant
+  RANDOM_SOURCE_SET_2 = '23456789'.freeze
+  RANDOM_SOURCE_UNION = RANDOM_SOURCE_SET_1.concat(RANDOM_SOURCE_SET_2)
+
+  def generate_reference_number
+    s = StringIO.new
+    (0..9).each do |i|
+      s << if i % 4 == 2
+             RANDOM_SOURCE_SET_2[SecureRandom.rand(RANDOM_SOURCE_SET_2.length)]
+           else
+             RANDOM_SOURCE_UNION[SecureRandom.rand(RANDOM_SOURCE_UNION.length)]
+           end
+      if [2, 6].include?(i)
+        s << '-'
+      end
+    end
+    s.string
+  end
+end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -30,9 +30,15 @@ module Platform
       }
     end
 
+    def concatenation_with_reference_number(text)
+      return text unless ENV['REFERENCE_NUMBER'].present? && user_data.key?('moj_forms_reference_number')
+
+      text.gsub('{{reference_number}}', user_data['moj_forms_reference_number'])
+    end
+
     def meta
       {
-        pdf_heading: ENV['SERVICE_EMAIL_PDF_HEADING'],
+        pdf_heading: concatenation_with_reference_number(ENV['SERVICE_EMAIL_PDF_HEADING']),
         pdf_subheading: ENV['SERVICE_EMAIL_PDF_SUBHEADING'].to_s,
         submission_at: Time.zone.now.iso8601
       }
@@ -98,8 +104,8 @@ module Platform
         kind: EMAIL,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
         from: ENV['SERVICE_EMAIL_FROM'],
-        subject: ENV['SERVICE_EMAIL_SUBJECT'],
-        email_body: ENV['SERVICE_EMAIL_BODY'],
+        subject: concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT']),
+        email_body: concatenation_with_reference_number(ENV['SERVICE_EMAIL_BODY']),
         include_attachments: true,
         include_pdf: true
       }
@@ -112,7 +118,7 @@ module Platform
         kind: CSV,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
         from: ENV['SERVICE_EMAIL_FROM'],
-        subject: "CSV - #{ENV['SERVICE_EMAIL_SUBJECT']}",
+        subject: "CSV - #{concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT'])}",
         email_body: '',
         include_attachments: true,
         include_pdf: false
@@ -126,8 +132,8 @@ module Platform
         kind: EMAIL,
         to: confirmation_email_answer,
         from: ENV['SERVICE_EMAIL_FROM'],
-        subject: ENV['CONFIRMATION_EMAIL_SUBJECT'],
-        email_body: ENV['CONFIRMATION_EMAIL_BODY'],
+        subject: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_SUBJECT']),
+        email_body: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_BODY']),
         include_attachments: true,
         include_pdf: true
       }

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -71,4 +71,33 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#update_session_with_reference_number_if_enabled' do
+    let(:session) { { 'user_data' => { 'num_number_1' => '42', 'email_email_1' => 'e@mail.com' } } }
+    before do
+      allow(ENV).to receive(:[])
+    end
+
+    context 'reference number is not enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('REFERENCE_NUMBER').and_return(nil)
+      end
+
+      it 'doesn\'t create or update a session key user_data' do
+        user_data = controller.update_session_with_reference_number_if_enabled(session)
+        expect(user_data.key?('moj_forms_reference_number')).to be_falsey
+      end
+    end
+
+    context 'when reference number is enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('REFERENCE_NUMBER').and_return('1')
+      end
+
+      it 'create or update a session key user_data' do
+        user_data = controller.update_session_with_reference_number_if_enabled(session)
+        expect(user_data.key?('moj_forms_reference_number')).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/controllers/helpers/reference_number_helper_spec.rb
+++ b/spec/controllers/helpers/reference_number_helper_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ReferenceNumberHelper, type: :helper do
+  describe '#generate reference number' do
+    let(:forbidden_array) { %w[0 O 1 I] }
+
+    it 'creates a 10 characters reference number' do
+      expect(helper.generate_reference_number.gsub('-', '').length).to eq(10)
+    end
+
+    it 'should have - after 3rd and 7th characters' do
+      expect(helper.generate_reference_number[3]).to eq('-')
+      expect(helper.generate_reference_number[8]).to eq('-')
+    end
+
+    it 'set 3rd and 7th characters as a number' do
+      expect(helper.generate_reference_number[2]).to be_in(ReferenceNumberHelper::RANDOM_SOURCE_SET_2)
+      expect(helper.generate_reference_number[7]).to be_in(ReferenceNumberHelper::RANDOM_SOURCE_SET_2)
+    end
+
+    it 'doesn\'t contains confusing characters such as 0, O, 1 and I' do
+      forbidden_array.each do |char|
+        expect(helper.generate_reference_number).not_to include(char)
+      end
+    end
+  end
+end

--- a/spec/services/aws_s3_client_spec.rb
+++ b/spec/services/aws_s3_client_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe AwsS3Client do
+  subject(:aws_s3_client) do
+    described_class.new
+  end
+
+  describe '#get_object' do
+    let(:bucket) { 'some-bucket' }
+    let(:object_key) { 'some-object-key' }
+    let(:response) { double(body: double(read: 'data')) }
+
+    let(:s3_object_stub) do
+      s3 = Aws::S3::Client.new(stub_responses: true)
+      s3.stub_responses(:get_object, { body: 'Hello!' })
+      s3
+    end
+
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('BUCKET_NAME').and_return(bucket)
+      allow_any_instance_of(AwsS3Client).to receive(:s3).and_return(s3_object_stub)
+    end
+
+    it 'should get an object from s3' do
+      expect(s3_object_stub).to receive(:get_object).with(
+        bucket: bucket,
+        key: object_key
+      ).and_return(response)
+
+      aws_s3_client.get_object(object_key)
+    end
+
+    it 'should read a response body' do
+      expect(aws_s3_client.get_object(object_key)).to eq('Hello!')
+    end
+  end
+end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -601,4 +601,38 @@ RSpec.describe Platform::SubmitterPayload do
       end
     end
   end
+
+  describe '#concatenation_with_reference_number' do
+    let(:dummy_reference) { '1234-ABC-567' }
+    let(:user_data) { double(session: session, key?: true) }
+    let(:text_without_reference_number) { 'email subject or email body.' }
+    let(:text_with_reference_number) { 'email subject or email body. Your reference number is {{reference_number}}' }
+
+    before do
+      allow(ENV).to receive(:[])
+      allow(user_data).to receive(:[]).with('moj_forms_reference_number').and_return(dummy_reference)
+    end
+
+    context 'reference is not enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('REFERENCE_NUMBER').and_return(nil)
+      end
+
+      it 'should return empty string' do
+        expect(submitter_payload.concatenation_with_reference_number(text_without_reference_number))
+        .to eq(text_without_reference_number)
+      end
+    end
+
+    context 'reference number is enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('REFERENCE_NUMBER').and_return('1')
+      end
+
+      it 'should return a reference number' do
+        expect(submitter_payload.concatenation_with_reference_number(text_with_reference_number))
+        .to eq(text_with_reference_number.gsub('{{reference_number}}', dummy_reference))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context
For tracking forms submissions we're adding a reference number unique to each submission. It is being generated when a end user confirm theirs answers in the confirmation page.

## Implementation
Implementing reference number in the runner. It checks if reference number is enabled in the environment variable. It generates a reference number at submission. It then adds the reference number in the placeholder {{reference_number}} in the email subject, the email body and the answers pdf for confirmation email and service email. 

## Tests
Unit tests have been updated but not the acceptance tests. Behaviour has been manually tested by deploying and running a small form and checking we're receiving emails in mailbox.

A end-user see the reference message:
<img width="670" alt="Screenshot 2022-12-02 at 12 56 50" src="https://user-images.githubusercontent.com/26165112/205298530-8f5125f1-da6d-42a3-a731-42a90c9e28f5.png">

The emails subject, body and attachment contains the same reference number:
<img width="621" alt="Screenshot 2022-12-02 at 13 03 50" src="https://user-images.githubusercontent.com/26165112/205299609-1c5c26ba-1f73-4cec-8a36-b96dfe68a3dc.png">

Both confirmation and service emails have their subject appended with reference number:
<img width="778" alt="Screenshot 2022-12-01 at 12 32 31" src="https://user-images.githubusercontent.com/26165112/205054159-7d53edaf-c304-448a-b7bb-f1207821e389.png">

The answers pdf also contain reference number:
<img width="573" alt="Screenshot 2022-12-01 at 12 33 03" src="https://user-images.githubusercontent.com/26165112/205054261-0fbd208e-3794-438d-a38d-fdd637679093.png">

