### PR TITLE
Add reference number to submitter payload

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -40,8 +40,9 @@ module Platform
       {
         pdf_heading: concatenation_with_reference_number(ENV['SERVICE_EMAIL_PDF_HEADING']),
         pdf_subheading: ENV['SERVICE_EMAIL_PDF_SUBHEADING'].to_s,
-        submission_at: Time.zone.now.iso8601
-      }
+        submission_at: Time.zone.now.iso8601,
+        reference_number: user_data['moj_forms_reference_number']
+      }.compact
     end
 
     def actions

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -437,6 +437,22 @@ RSpec.describe Platform::SubmitterPayload do
             )
           end
         end
+
+        context 'when reference number is not present' do
+          it 'does not include the reference number' do
+            expect(submitter_payload.to_h[:meta].key?(:reference_number)).to be_falsey
+          end
+        end
+
+        context 'when reference number is present' do
+          let(:reference_number) { 'some-reference-number' }
+          let(:user_data) { { 'moj_forms_reference_number' => reference_number } }
+
+          it 'adds the reference number attribute and value' do
+            meta_payload = submitter_payload.to_h[:meta]
+            expect(meta_payload[:reference_number]).to eq(reference_number)
+          end
+        end
       end
 
       it 'does not send any content components text in the payload' do


### PR DESCRIPTION
There is a need for the reference number for a submission to be injected into other types of payloads when being processed by the submitter. Until now the reference number has only been present in some of the payload strings such as email subjects or email bodies.

Set the reference number as an attribute on the meta payload, should it be present in the user_data, and then send that along with the other meta attributes to the submitter.

We do not add it as part of the user answers as technically the user did not add it themselves, and also there are no component id or component field attributes relating to the reference number since it does not have its' own component.