### PR TITLE
Use Metadata Presenter 2.17.27

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.17.25'
+gem 'metadata_presenter', '2.17.27'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.6'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.25)
+    metadata_presenter (2.17.27)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -361,7 +361,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.17.25)
+  metadata_presenter (= 2.17.27)
   prometheus-client (~> 2.1.0)
   puma (~> 5.6)
   rails (>= 6.1.4.6)

--- a/spec/support/pages/version_fixture.rb
+++ b/spec/support/pages/version_fixture.rb
@@ -22,7 +22,6 @@ class VersionFixture < SitePrism::Page
   element :mando_name, :radio_button, 'Din Jarrin'
   element :country_field, :field, 'Countries'
   element :back_link, :link, 'Back'
-  element :multiple_questions_heading, 'h3'
   elements :error_summary_list, '.govuk-error-summary__list'
   elements :inline_error_messages, '.govuk-error-message'
   elements :summary_list, '.govuk-summary-list__row'
@@ -42,6 +41,10 @@ class VersionFixture < SitePrism::Page
     inline_error_messages.map do |error_message|
       error_message.text.gsub('Error: ', '')
     end
+  end
+
+  def multiple_questions_heading
+    page.find(:css, 'h2', text: 'How well do you know Star Wars?')
   end
 
   def full_name_checkanswers


### PR DESCRIPTION
Brings in:

- Check answers page H2 tag changes for accessibility
- Confirmation page reference number content update