### PR TITLE
Inject payment link into confirmation email body

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -134,7 +134,7 @@ module Platform
         to: confirmation_email_answer,
         from: ENV['SERVICE_EMAIL_FROM'],
         subject: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_SUBJECT']),
-        email_body: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_BODY']),
+        email_body: inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']),
         include_attachments: true,
         include_pdf: true
       }
@@ -189,6 +189,14 @@ module Platform
 
     def confirmation_email_answer
       @confirmation_email_answer ||= user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]
+    end
+
+    def inject_reference_payment_content(text)
+      concatenation_with_reference_number(text).gsub('{{payment_link}}', payment_reference)
+    end
+
+    def payment_reference
+      "#{ENV['PAYMENT_LINK']}#{user_data['moj_forms_reference_number']}"
     end
   end
 end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -31,9 +31,7 @@ module Platform
     end
 
     def concatenation_with_reference_number(text)
-      return text unless ENV['REFERENCE_NUMBER'].present? && user_data.key?('moj_forms_reference_number')
-
-      text.gsub('{{reference_number}}', user_data['moj_forms_reference_number'])
+      text.gsub('{{reference_number}}', user_data['moj_forms_reference_number'] || '')
     end
 
     def meta


### PR DESCRIPTION
When there is a {{payment_link}} placeholder in the confirmation email
body we want to replace this with the actual payment link which is
present in ENV['PAYMENT_LINK'].

Also if {{reference_number}} is not present in the text that needs to be
mutated the call to gsub will no op. If the user_data object does not
contain the property 'moj_forms_reference_number' then we can fall back
to just returning an empty string.