### PR TITLE
Append reference params to the payment link url

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -194,7 +194,7 @@ module Platform
     end
 
     def payment_reference
-      "#{ENV['PAYMENT_LINK']}#{user_data['moj_forms_reference_number']}"
+      "#{ENV['PAYMENT_LINK']}?reference=#{user_data['moj_forms_reference_number']}"
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -631,13 +631,13 @@ RSpec.describe Platform::SubmitterPayload do
   end
 
   context 'payment links' do
-    let(:payment_link) { 'http://www.mustafa.com/vader-tax?reference=' }
+    let(:payment_link) { 'http://www.mustafa.com/vader-tax' }
     let(:dummy_reference) { '1234-ABC-567' }
     let(:confirmation_email_body) do
       'some email body {{payment_link}}'
     end
     let(:expected_confirmation_email_body) do
-      "some email body #{payment_link}#{dummy_reference}"
+      "some email body #{payment_link}?reference=#{dummy_reference}"
     end
     let(:expected_actions) do
       [


### PR DESCRIPTION
We want to add the reference param to the payment link url, and before the generated reference number.