### PR TITLE
Add continue to pay button

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.17.28'
+gem 'metadata_presenter', '2.17.29'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.0'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.28)
+    metadata_presenter (2.17.29)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -361,7 +361,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.17.28)
+  metadata_presenter (= 2.17.29)
   prometheus-client (~> 2.1.0)
   puma (~> 6.0)
   rails (>= 6.1.4.6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -117,4 +117,9 @@ class ApplicationController < ActionController::Base
     ENV['PAYMENT_LINK'].present?
   end
   helper_method :payment_link_enabled?
+
+  def payment_link_url
+    ENV['PAYMENT_LINK']
+  end
+  helper_method :payment_link_url
 end


### PR DESCRIPTION
Bump metadata presenter to 2.17.29 to include the continue to pay button, and add the required methods into the `ApplicationController`.

![image](https://user-images.githubusercontent.com/595564/208144137-228d535b-e0c0-4986-9cb5-566a2e650e97.png)
