### PR TITLE
Fix payment_link_url to include reference number

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -119,7 +119,7 @@ class ApplicationController < ActionController::Base
   helper_method :payment_link_enabled?
 
   def payment_link_url
-    ENV['PAYMENT_LINK']
+    ENV['PAYMENT_LINK'] + show_reference_number
   end
   helper_method :payment_link_url
 end


### PR DESCRIPTION
Update the payment_link_url to include the reference number so that the link is actually correct!