### PR TITLE
Confirmation email bug fix

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -186,7 +186,7 @@ module Platform
     end
 
     def confirmation_email_answer
-      @confirmation_email_answer ||= user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]
+      @confirmation_email_answer ||= confirmation_email if user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']].present?
     end
 
     def inject_reference_payment_content(text)
@@ -195,6 +195,14 @@ module Platform
 
     def payment_reference
       "#{ENV['PAYMENT_LINK']}#{user_data['moj_forms_reference_number']}"
+    end
+
+    def confirmation_email
+      if user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] == ENV['SERVICE_EMAIL_OUTPUT']
+        user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']].gsub('@', '+confirmation@')
+      else
+        user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]
+      end
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -600,6 +600,46 @@ RSpec.describe Platform::SubmitterPayload do
         expect(subject.actions).to be_empty
       end
     end
+
+    context 'when email output and confirmation email to address are the same' do
+      let(:email_to) do
+        'legolas@middle.earth.com'
+      end
+      let(:confirmation_to) do
+        'legolas+confirmation@middle.earth.com'
+      end
+      let(:expected_actions) do
+        [
+          {
+            kind: 'email',
+            to: email_to,
+            from: email_from,
+            subject: email_subject,
+            email_body: email_body,
+            include_pdf: true,
+            include_attachments: true
+          },
+          {
+            kind: 'email',
+            to: confirmation_to,
+            from: email_from,
+            subject: confirmation_email_subject,
+            email_body: confirmation_email_body,
+            include_pdf: true,
+            include_attachments: true
+          }
+        ]
+      end
+
+      before do
+        allow(ENV).to receive(:[]).with('SERVICE_EMAIL_OUTPUT').and_return(email_to)
+        allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_COMPONENT_ID').and_return(email_component_id)
+      end
+
+      it 'should return confirmation email to address with "+confirmation@"' do
+        expect(subject.actions).to eq(expected_actions)
+      end
+    end
   end
 
   describe '#concatenation_with_reference_number' do


### PR DESCRIPTION
We have a bug whereby if the form editor uses the same email for the `ENV['SERVICE_EMAIL_OUTPUT']` and the `user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]`, only the service email will be sent.

This is because, when the submitter app receives the submitter payload from the Runner, it only sends emails that are unique based on the 'to' email address and the 'attachments'. Since in the case of the service email and the confirmation email, both the 'to' address and the 'attachments' will be identical, only one email will be sent.
This bug only affects form editors that would use the same 'to' email for both submission and confirmation emails for testing purposes.

To mitigate this bug, we can append a '+confirmation' string to the email address that is submitted for the confirmation email if it is the same as the service email output.