### PR TITLE
Apply GOVUK link styles to (editable) content areas

### DIFF
--- a/app/javascript/styles/shared/_content.scss
+++ b/app/javascript/styles/shared/_content.scss
@@ -10,3 +10,8 @@
 .call-to-action > p {
   margin: 0;
 }
+
+// Apply GOVUk link styles to all links in editable content areas
+.fb-editable[data-fb-content-type="content"] a {
+  @extend %govuk-link;
+}


### PR DESCRIPTION
This adds the standard GOVUK link styles to links within editable<sup>^</sup> content areas.

This is in the shared/_content.scss file as it applies both within the editor and in the preview (matching PR in the editor: https://github.com/ministryofjustice/fb-editor/pull/2040)

<sup>^</sup> editable in the editor obviously, but they still have the editable attributes we can use to find them and style them.