### PR TITLE
Import GOVUK settings, tools and helpers to be able to use govuk-link mixin

### DIFF
--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -14,5 +14,13 @@
  *= require_self
  */
 
-@import "govuk-frontend/govuk/helpers/colour";
+$govuk-assets-path: "~govuk-frontend/govuk/assets/";
+
+// Including all of the settings tools and helpers for potential future use.
+// These don't generate any CSS output so there is no harm in importing them all.
+@import "govuk-frontend/govuk/settings/all";
+@import "govuk-frontend/govuk/tools/all";
+@import "govuk-frontend/govuk/helpers/all";
+
+@import "govuk-frontend/govuk/core/links";
 @import "./shared/content";


### PR DESCRIPTION
Previous attempt at doing this didn't work as the scss file didn't have access to the required variables and mixins required from the rest of GOVUK frontend scss framework.

Have included all the settings, helpers and tools as they will potentially be useful in the future - and don't add any extra compiled css to the output.