### PR TITLE
Add session expired redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.17.33'
+gem 'metadata_presenter', '2.17.34'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.0'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.33)
+    metadata_presenter (2.17.34)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -361,7 +361,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.17.33)
+  metadata_presenter (= 2.17.34)
   prometheus-client (~> 2.1.0)
   puma (~> 6.0)
   rails (>= 6.1.4.6)

--- a/app/filters/verify_session.rb
+++ b/app/filters/verify_session.rb
@@ -2,7 +2,7 @@ class VerifySession
   def self.before(controller)
     if !allowed_pages?(controller) && controller.session[:session_id].blank?
       controller.reset_session
-      controller.redirect_to controller.root_path
+      controller.redirect_to '/session/expired'
     end
   end
 

--- a/spec/requests/verify_session_spec.rb
+++ b/spec/requests/verify_session_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe 'verify session', type: :request do
+  let(:session_expired_path) { '/session/expired' }
+
   context 'when session id exists' do
     before do
       allow_any_instance_of(
@@ -14,7 +16,7 @@ RSpec.describe 'verify session', type: :request do
       end
 
       it 'does not redirect the user' do
-        expect(response).to_not redirect_to('/')
+        expect(response).to_not redirect_to(session_expired_path)
       end
     end
   end
@@ -26,7 +28,7 @@ RSpec.describe 'verify session', type: :request do
       end
 
       it 'does not redirect the user' do
-        expect(response).to_not redirect_to('/')
+        expect(response).to_not redirect_to(session_expired_path)
       end
     end
 
@@ -36,7 +38,7 @@ RSpec.describe 'verify session', type: :request do
       end
 
       it 'does not redirect the user' do
-        expect(response).to_not redirect_to('/')
+        expect(response).to_not redirect_to(session_expired_path)
       end
     end
 
@@ -46,7 +48,7 @@ RSpec.describe 'verify session', type: :request do
       end
 
       it 'redirects the user' do
-        expect(response).to redirect_to('/')
+        expect(response).to redirect_to(session_expired_path)
       end
     end
   end


### PR DESCRIPTION
Changes the redirect when the session has expired to redirect to the session/expired route in order to show an explanatory message to the user.

**Technically** this code does the redirect if the session does not exist.  This is beacuse that is all we can do with the standard Rails `SessionStore` cookie.  By default the cookie has an expires after attribute (e.g. 60mins) and it isn't possible to read out the actual expiry time from the cookie in the code.  

I attempted to attach an expires at time to the cookie, but this can't actually be read when needed as by the time the request reaches the controller code it has been through Rack, which has already checked its validity and reomoved it if it has expired

This means that when we want to handle expiry times ourselves, we will probably have to leave this 1hr sessioncookie in place and create our own cookie to track an expiry time, which we can update as required and then reset the session cookie when it has expired.