### PR TITLE
Reply to

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,35 +234,36 @@ workflows:
             branches:
               only:
                 - main
+                - reply-to
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      - deploy_to_test_production:
-          context: *moj-forms-context
-          requires:
-            - build_and_push_image_test
+      # - deploy_to_test_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - build_and_push_image_test
       - acceptance_tests:
           context: *moj-forms-context
           requires:
             - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+            # - deploy_to_test_production
+      # - build_and_push_image_live:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      # - deploy_to_live_dev:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - deploy_to_live_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - smoke_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -26,7 +26,7 @@ module Platform
       {
         id: service.service_id,
         slug: service.service_slug,
-        name: service.service_name
+        name: service_name
       }
     end
 
@@ -102,7 +102,7 @@ module Platform
       {
         kind: EMAIL,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: ENV['SERVICE_EMAIL_FROM'],
+        from: email_from,
         subject: concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT']),
         email_body: concatenation_with_reference_number(ENV['SERVICE_EMAIL_BODY']),
         include_attachments: true,
@@ -116,7 +116,7 @@ module Platform
       {
         kind: CSV,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: ENV['SERVICE_EMAIL_FROM'],
+        from: email_from,
         subject: "CSV - #{concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT'])}",
         email_body: '',
         include_attachments: true,
@@ -130,7 +130,7 @@ module Platform
       {
         kind: EMAIL,
         to: confirmation_email_answer,
-        from: ENV['SERVICE_EMAIL_FROM'],
+        from: email_from,
         subject: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_SUBJECT']),
         email_body: inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']),
         include_attachments: true,
@@ -203,6 +203,14 @@ module Platform
       else
         user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]
       end
+    end
+
+    def service_name
+      @service_name ||= service.service_name
+    end
+
+    def email_from
+      @email_from ||= "#{service_name} <#{ENV['SERVICE_EMAIL_FROM']}>"
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -60,7 +60,10 @@ RSpec.describe Platform::SubmitterPayload do
     'middle.earth.entertainment@magazine.co.uk'
   end
   let(:email_from) do
-    'MoJ forms <moj-online@digital.justice.gov.uk>'
+    'moj-online@digital.justice.gov.uk'
+  end
+  let(:expected_email_from) do
+    'Version Fixture <moj-online@digital.justice.gov.uk>'
   end
   let(:email_subject) do
     'All info about middle earth characters'
@@ -223,7 +226,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: email_to,
-          from: email_from,
+          from: expected_email_from,
           subject: email_subject,
           email_body: email_body,
           include_pdf: true,
@@ -232,7 +235,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'csv',
           to: email_to,
-          from: email_from,
+          from: expected_email_from,
           subject: "CSV - #{email_subject}",
           email_body: '',
           include_pdf: false,
@@ -241,7 +244,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: user_data[email_component_id],
-          from: email_from,
+          from: expected_email_from,
           subject: confirmation_email_subject,
           email_body: confirmation_email_body,
           include_pdf: true,
@@ -494,7 +497,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: email_from,
+            from: expected_email_from,
             subject: email_subject,
             email_body: email_body,
             include_pdf: true,
@@ -503,7 +506,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'csv',
             to: email_to,
-            from: email_from,
+            from: expected_email_from,
             subject: "CSV - #{email_subject}",
             email_body: '',
             include_pdf: false,
@@ -512,7 +515,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: user_data[email_component_id],
-            from: email_from,
+            from: expected_email_from,
             subject: confirmation_email_subject,
             email_body: confirmation_email_body,
             include_pdf: true,
@@ -538,7 +541,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: email_from,
+            from: expected_email_from,
             subject: email_subject,
             email_body: email_body,
             include_pdf: true,
@@ -561,7 +564,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: user_data[email_component_id],
-            from: email_from,
+            from: expected_email_from,
             subject: confirmation_email_subject,
             email_body: confirmation_email_body,
             include_pdf: true,
@@ -613,7 +616,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: email_from,
+            from: expected_email_from,
             subject: email_subject,
             email_body: email_body,
             include_pdf: true,
@@ -622,7 +625,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: confirmation_to,
-            from: email_from,
+            from: expected_email_from,
             subject: confirmation_email_subject,
             email_body: confirmation_email_body,
             include_pdf: true,
@@ -684,7 +687,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: user_data[email_component_id],
-          from: email_from,
+          from: expected_email_from,
           subject: confirmation_email_subject,
           email_body: expected_confirmation_email_body,
           include_pdf: true,


### PR DESCRIPTION
### Prepend service name to from address

Currently, when an end user receives a confirmation email from a service, the from email address is displayed or (if the service is using the default from address) the default MoJ Forms email address is displayed.

We would like to prepend the email address in the 'from' and the 'reply-to' with the service name. This is so the emails received appear as though they are coming from the service.

We are doing this change in the Runner as the Submitter app, which is currently being used for both the V1/legacy Runner and V2 apps, needs to receive similar payloads.

In the Legacy Runner app, we also prepend the service name to the email from, [see runner node code](https://github.com/ministryofjustice/fb-runner-node/blob/master/lib/controller/page/type/page.summary/index.js#L192).

Since we have a default `SERVICE_EMAIL_FROM` env var that is injected from the Editor app ([see this code snippet](https://github.com/ministryofjustice/fb-editor/blob/main/app/models/base_email_settings.rb#L19) and [this code snippet](https://github.com/ministryofjustice/fb-editor/blob/main/config/locales/en.yml#L29)) and a default email from in the legacy app - we will always pass an email from address to the Submitter app.