### PR TITLE
Upgrading Presenter version to 2.17.35

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'jwt'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
 #
 gem 'fb-jwt-auth', '0.8.0'
-gem 'metadata_presenter', '2.17.34'
+gem 'metadata_presenter', '2.17.35'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.0'
 gem 'rails', '>= 6.1.4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (2.17.34)
+    metadata_presenter (2.17.35)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -361,7 +361,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.8.0)
   jwt
   listen (~> 3.7)
-  metadata_presenter (= 2.17.34)
+  metadata_presenter (= 2.17.35)
   prometheus-client (~> 2.1.0)
   puma (~> 6.0)
   rails (>= 6.1.4.6)


### PR DESCRIPTION
We update the version of the presenter to see the update of the cookie statement expiring from now on to 60 minutes