### PR TITLE
Filestore unavailable raise type error in forms

### DIFF
--- a/app/models/user_data_params.rb
+++ b/app/models/user_data_params.rb
@@ -18,6 +18,9 @@ class UserDataParams
       @page_answers.uploaded_files.map do |uploaded_file|
         @answer_params[uploaded_file.component.id] =
           @page_answers.send(uploaded_file.component.id).merge(uploaded_file.file)
+
+      rescue Platform::FilestoreError
+        Rails.logger.info("Error while retrieving #{uploaded_file} from filestore")
       end
     end
   end


### PR DESCRIPTION
This is to catch the error when the Filestore is not available and the runner cannot get the uploaded file. This is an error that has been occurring sporadicaly since 2021. This small change ran ok with the the acceptance tests:
<img width="984" alt="Screenshot 2023-02-15 at 15 50 21" src="https://user-images.githubusercontent.com/26165112/219085417-c4207d40-5c31-4bef-84ae-37f07449a27e.png">

