### PR TITLE
Reply-To: Allow backwards compatibility for reply-to/from address env var

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -5,6 +5,7 @@ module Platform
 
     CSV = 'csv'.freeze
     EMAIL = 'email'.freeze
+    DEFAULT_EMAIL_ADDRESS = 'no-reply-moj-forms@digital.justice.gov.uk'.freeze
 
     def initialize(service:, user_data:, session:)
       @service = service
@@ -102,7 +103,7 @@ module Platform
       {
         kind: EMAIL,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: confirmation_email_reply_to,
+        from: DEFAULT_EMAIL_ADDRESS,
         subject: concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT']),
         email_body: concatenation_with_reference_number(ENV['SERVICE_EMAIL_BODY']),
         include_attachments: true,
@@ -116,7 +117,7 @@ module Platform
       {
         kind: CSV,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: confirmation_email_reply_to,
+        from: DEFAULT_EMAIL_ADDRESS,
         subject: "CSV - #{concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT'])}",
         email_body: '',
         include_attachments: true,

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -102,7 +102,7 @@ module Platform
       {
         kind: EMAIL,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: ENV['SERVICE_EMAIL_FROM'],
+        from: confirmation_email_reply_to,
         subject: concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT']),
         email_body: concatenation_with_reference_number(ENV['SERVICE_EMAIL_BODY']),
         include_attachments: true,
@@ -116,7 +116,7 @@ module Platform
       {
         kind: CSV,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: ENV['SERVICE_EMAIL_FROM'],
+        from: confirmation_email_reply_to,
         subject: "CSV - #{concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT'])}",
         email_body: '',
         include_attachments: true,
@@ -130,7 +130,7 @@ module Platform
       {
         kind: EMAIL,
         to: confirmation_email_answer,
-        from: ENV['SERVICE_EMAIL_FROM'],
+        from: confirmation_email_reply_to,
         subject: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_SUBJECT']),
         email_body: inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']),
         include_attachments: true,
@@ -203,6 +203,10 @@ module Platform
       else
         user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']]
       end
+    end
+
+    def confirmation_email_reply_to
+      @confirmation_email_reply_to ||= ENV['CONFIRMATION_EMAIL_REPLY_TO'].presence || ENV['SERVICE_EMAIL_FROM']
     end
   end
 end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -103,7 +103,7 @@ module Platform
       {
         kind: EMAIL,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: DEFAULT_EMAIL_ADDRESS,
+        from: default_email_from,
         subject: concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT']),
         email_body: concatenation_with_reference_number(ENV['SERVICE_EMAIL_BODY']),
         include_attachments: true,
@@ -117,7 +117,7 @@ module Platform
       {
         kind: CSV,
         to: ENV['SERVICE_EMAIL_OUTPUT'],
-        from: DEFAULT_EMAIL_ADDRESS,
+        from: default_email_from,
         subject: "CSV - #{concatenation_with_reference_number(ENV['SERVICE_EMAIL_SUBJECT'])}",
         email_body: '',
         include_attachments: true,
@@ -206,8 +206,20 @@ module Platform
       end
     end
 
+    def confirmation_email_from_address
+      @confirmation_email_from_address ||= ENV['CONFIRMATION_EMAIL_REPLY_TO'].presence || ENV['SERVICE_EMAIL_FROM']
+    end
+
+    def service_name
+      @service_name ||= service.service_name
+    end
+
     def confirmation_email_reply_to
-      @confirmation_email_reply_to ||= ENV['CONFIRMATION_EMAIL_REPLY_TO'].presence || ENV['SERVICE_EMAIL_FROM']
+      @confirmation_email_reply_to ||= "#{service_name} <#{confirmation_email_from_address}>"
+    end
+
+    def default_email_from
+      @default_email_from ||= "#{service_name} <#{DEFAULT_EMAIL_ADDRESS}>"
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -60,10 +60,19 @@ RSpec.describe Platform::SubmitterPayload do
     'middle.earth.entertainment@magazine.co.uk'
   end
   let(:email_from) do
-    'MoJ forms <moj-online@digital.justice.gov.uk>'
+    'moj-online@digital.justice.gov.uk'
+  end
+  let(:expected_email_from) do
+    "Version Fixture <#{email_from}>"
+  end
+  let(:expected_default_email_from) do
+    "Version Fixture <#{default_email_address}>"
   end
   let(:confirmation_email_reply_to) do
-    'MoJ forms <reply_to@digital.justice.gov.uk>'
+    'reply_to@digital.justice.gov.uk'
+  end
+  let(:expected_confirmation_email_reply_to) do
+    'Version Fixture <reply_to@digital.justice.gov.uk>'
   end
   let(:default_email_address) { Platform::SubmitterPayload::DEFAULT_EMAIL_ADDRESS }
   let(:email_subject) do
@@ -227,7 +236,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: email_to,
-          from: default_email_address,
+          from: expected_default_email_from,
           subject: email_subject,
           email_body:,
           include_pdf: true,
@@ -236,7 +245,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'csv',
           to: email_to,
-          from: default_email_address,
+          from: expected_default_email_from,
           subject: "CSV - #{email_subject}",
           email_body: '',
           include_pdf: false,
@@ -245,7 +254,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: user_data[email_component_id],
-          from: email_from,
+          from: expected_email_from,
           subject: confirmation_email_subject,
           email_body: confirmation_email_body,
           include_pdf: true,
@@ -498,7 +507,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: default_email_address,
+            from: expected_default_email_from,
             subject: email_subject,
             email_body:,
             include_pdf: true,
@@ -507,7 +516,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'csv',
             to: email_to,
-            from: default_email_address,
+            from: expected_default_email_from,
             subject: "CSV - #{email_subject}",
             email_body: '',
             include_pdf: false,
@@ -516,7 +525,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: user_data[email_component_id],
-            from: email_from,
+            from: expected_email_from,
             subject: confirmation_email_subject,
             email_body: confirmation_email_body,
             include_pdf: true,
@@ -542,7 +551,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: default_email_address,
+            from: expected_default_email_from,
             subject: email_subject,
             email_body:,
             include_pdf: true,
@@ -565,7 +574,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: user_data[email_component_id],
-            from: email_from,
+            from: expected_email_from,
             subject: confirmation_email_subject,
             email_body: confirmation_email_body,
             include_pdf: true,
@@ -617,7 +626,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: default_email_address,
+            from: expected_default_email_from,
             subject: email_subject,
             email_body:,
             include_pdf: true,
@@ -626,7 +635,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: confirmation_to,
-            from: email_from,
+            from: expected_email_from,
             subject: confirmation_email_subject,
             email_body: confirmation_email_body,
             include_pdf: true,
@@ -688,7 +697,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: user_data[email_component_id],
-          from: email_from,
+          from: expected_email_from,
           subject: confirmation_email_subject,
           email_body: expected_confirmation_email_body,
           include_pdf: true,
@@ -719,7 +728,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: email_to,
-          from: default_email_address,
+          from: expected_default_email_from,
           subject: email_subject,
           email_body:,
           include_pdf: true,
@@ -728,7 +737,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'csv',
           to: email_to,
-          from: default_email_address,
+          from: expected_default_email_from,
           subject: "CSV - #{email_subject}",
           email_body: '',
           include_pdf: false,
@@ -774,13 +783,13 @@ RSpec.describe Platform::SubmitterPayload do
       before do
         allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_REPLY_TO').and_return(confirmation_email_reply_to)
       end
-      let(:expected_email) { confirmation_email_reply_to }
+      let(:expected_email) { expected_confirmation_email_reply_to }
 
       it_behaves_like 'a reply to email action'
     end
 
     context 'when reply to email is not present' do
-      let(:expected_email) { email_from }
+      let(:expected_email) { expected_email_from }
 
       it_behaves_like 'a reply to email action'
     end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe Platform::SubmitterPayload do
   let(:confirmation_email_reply_to) do
     'MoJ forms <reply_to@digital.justice.gov.uk>'
   end
+  let(:default_email_address) { Platform::SubmitterPayload::DEFAULT_EMAIL_ADDRESS }
   let(:email_subject) do
     'All info about middle earth characters'
   end
@@ -226,7 +227,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: email_to,
-          from: email_from,
+          from: default_email_address,
           subject: email_subject,
           email_body:,
           include_pdf: true,
@@ -235,7 +236,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'csv',
           to: email_to,
-          from: email_from,
+          from: default_email_address,
           subject: "CSV - #{email_subject}",
           email_body: '',
           include_pdf: false,
@@ -497,7 +498,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: email_from,
+            from: default_email_address,
             subject: email_subject,
             email_body:,
             include_pdf: true,
@@ -506,7 +507,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'csv',
             to: email_to,
-            from: email_from,
+            from: default_email_address,
             subject: "CSV - #{email_subject}",
             email_body: '',
             include_pdf: false,
@@ -541,7 +542,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: email_from,
+            from: default_email_address,
             subject: email_subject,
             email_body:,
             include_pdf: true,
@@ -616,7 +617,7 @@ RSpec.describe Platform::SubmitterPayload do
           {
             kind: 'email',
             to: email_to,
-            from: email_from,
+            from: default_email_address,
             subject: email_subject,
             email_body:,
             include_pdf: true,
@@ -718,7 +719,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'email',
           to: email_to,
-          from: expected_email,
+          from: default_email_address,
           subject: email_subject,
           email_body:,
           include_pdf: true,
@@ -727,7 +728,7 @@ RSpec.describe Platform::SubmitterPayload do
         {
           kind: 'csv',
           to: email_to,
-          from: expected_email,
+          from: default_email_address,
           subject: "CSV - #{email_subject}",
           email_body: '',
           include_pdf: false,


### PR DESCRIPTION
### Reply-To: Allow backwards compatibility for reply-to/from address
We have changed the functionality of the from address in the Editor to now inject a 'SERVICE_EMAIL_REPLY_TO' env var.
To ensure backwards compatibility we need to check whether a 'SERVICE_EMAIL_REPLY_TO' variable exists. If it does we should use it, if it does not, we can use the 'SERVICE_EMAIL_FROM' variable.


### Update the from address for 'collect information by email' config
Now that the from address is configured in the confirmation email settings page in the Editor. We want to default the from address for the 'Collect Information by Email' config to the MoJ Forms default email address.