### PR TITLE
Delete session on submit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,36 +234,35 @@ workflows:
             branches:
               only:
                 - main
-                - delete-session-submit
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-#      - deploy_to_test_production:
-#          context: *moj-forms-context
-#          requires:
-#            - build_and_push_image_test
-#      - acceptance_tests:
-#          context: *moj-forms-context
-#          requires:
-#            - deploy_to_test_dev
-#            - deploy_to_test_production
-#      - build_and_push_image_live:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#      - deploy_to_live_dev:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#      - deploy_to_live_production:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#      - smoke_tests:
-#          context: *moj-forms-context
-#          requires:
-#            - deploy_to_live_dev
-#            - deploy_to_live_production
+      - deploy_to_test_production:
+          context: *moj-forms-context
+          requires:
+            - build_and_push_image_test
+      - acceptance_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_test_dev
+            - deploy_to_test_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,35 +234,36 @@ workflows:
             branches:
               only:
                 - main
+                - delete-session-submit
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      - deploy_to_test_production:
-          context: *moj-forms-context
-          requires:
-            - build_and_push_image_test
-      - acceptance_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+#      - deploy_to_test_production:
+#          context: *moj-forms-context
+#          requires:
+#            - build_and_push_image_test
+#      - acceptance_tests:
+#          context: *moj-forms-context
+#          requires:
+#            - deploy_to_test_dev
+#            - deploy_to_test_production
+#      - build_and_push_image_live:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#      - deploy_to_live_dev:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#      - deploy_to_live_production:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#      - smoke_tests:
+#          context: *moj-forms-context
+#          requires:
+#            - deploy_to_live_dev
+#            - deploy_to_live_production

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action VerifySession
 
   add_flash_types :confirmation, :expired_session
+  rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_expired_page
 
   EXCEPTIONS = [
     Platform::TimeoutError,
@@ -129,5 +130,9 @@ class ApplicationController < ActionController::Base
 
   def delete_session
     flash[:confirmation] = 'Session will expired'
+  end
+
+  def redirect_to_expired_page
+    redirect_to '/session/expired'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   before_action :require_basic_auth
   before_action VerifySession
 
+  add_flash_types :confirmation, :expired_session
+
   EXCEPTIONS = [
     Platform::TimeoutError,
     Platform::ClientError
@@ -70,6 +72,8 @@ class ApplicationController < ActionController::Base
       session:
     ).save
     # rubocop: enable Rails/SaveBang
+
+    delete_session
   end
 
   def editable?
@@ -122,4 +126,8 @@ class ApplicationController < ActionController::Base
     ENV['PAYMENT_LINK'] + show_reference_number
   end
   helper_method :payment_link_url
+
+  def delete_session
+    flash[:confirmation] = 'Session will expired'
+  end
 end

--- a/app/filters/verify_session.rb
+++ b/app/filters/verify_session.rb
@@ -1,5 +1,12 @@
 class VerifySession
   def self.before(controller)
+    if !allowed_pages?(controller) && controller.flash[:expired_session].present?
+      controller.reset_session
+      controller.redirect_to '/session/expired'
+    end
+    if !allowed_pages?(controller) && controller.flash[:confirmation].present?
+      controller.flash[:expired_session] = 'Session has expired'
+    end
     if !allowed_pages?(controller) && controller.session[:session_id].blank?
       controller.reset_session
       controller.redirect_to '/session/expired'

--- a/spec/requests/verify_session_spec.rb
+++ b/spec/requests/verify_session_spec.rb
@@ -2,21 +2,41 @@ RSpec.describe 'verify session', type: :request do
   let(:session_expired_path) { '/session/expired' }
 
   context 'when session id exists' do
-    before do
-      allow_any_instance_of(
-        ActionDispatch::Request
-      ).to receive(:session).and_return(
-        { session_id: SecureRandom.hex(24) }
-      )
+    let(:dummy_session) do
+      {
+        session_id: SecureRandom.hex(24),
+        user_id: 'eb380609ce7706bb930b5991c8acc51f',
+        user_data:
+          {
+            'num_number_1' => '42',
+            'email_email_1' => 'e@mail.com',
+            'moj_forms_reference_number' => 'TX4-KHM5-JTN'
+          }
+      }
     end
 
     context 'when other page' do
       before do
+        allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(dummy_session)
         get '/name'
       end
-
       it 'does not redirect the user' do
         expect(response).to_not redirect_to(session_expired_path)
+      end
+    end
+
+    context 'when we reach the end of the form and submit' do
+      before do
+        allow(controller).to receive(:session).and_return(:dummy_session)
+        get '/form-sent'
+      end
+
+      it 'redirects the user to timeout page' do
+        expect(response).to redirect_to(session_expired_path)
+      end
+
+      it 'and has cleared the user session' do
+        expect(controller.session[:user_data]).to be_falsey
       end
     end
   end


### PR DESCRIPTION
[Trello](https://trello.com/c/QOUPgM0p/3281-delete-session-on-submit)

## Goal
Problem was being able to get the session after submitting the form. Even if the submission can be differentiated by reference number, it was still possible to re upload and change submission, this was a problem for the cop form where documents were uploaded by solicitors.

## Implementation
We would like to delete session after submission of the form data to the submitter. We use flash part of the session that is being purged after next request. We're using 2 steps so it doesn't redirect straight away to expired session page after submission. Limitation at the moment is the back button behaviour. It is still possible to get the session held in the client using the back button.

## Testing
Unit and manual testing locally and in test-dev. 


