### PR TITLE
Lengthen timeouts and set read_timeout explicitly on Faraday connection

### DIFF
--- a/app/services/platform/connection.rb
+++ b/app/services/platform/connection.rb
@@ -18,6 +18,7 @@ module Platform
         conn.use :instrumentation, name: subscription
         conn.options[:open_timeout] = timeout
         conn.options[:timeout] = timeout
+        conn.options[:read_timeout] = timeout
 
         # Submitter uses the v3 access token from service token cache
         conn.request :authorization, 'Bearer', service_access_token

--- a/app/services/platform/submitter_adapter.rb
+++ b/app/services/platform/submitter_adapter.rb
@@ -5,7 +5,7 @@ module Platform
     attr_reader :payload, :session, :root_url, :service_slug, :service_secret
 
     SUBSCRIPTION = 'submitter.request'.freeze
-    TIMEOUT = 15
+    TIMEOUT = 30
     V2_URL = '/v2/submissions'.freeze
 
     def initialize(payload:,

--- a/app/services/platform/user_datastore_adapter.rb
+++ b/app/services/platform/user_datastore_adapter.rb
@@ -1,7 +1,7 @@
 module Platform
   class UserDatastoreAdapter
     include Platform::Connection
-    TIMEOUT = 15
+    TIMEOUT = 30
     SUBSCRIPTION = 'datastore.request'.freeze
 
     attr_reader :session, :root_url, :service_slug


### PR DESCRIPTION
This should hopefully alleviate errors we see on the large forms when they make larger/longer running user-datastore read requests