### PR TITLE
This change removes the robots.txt file from the Docker build.

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
This seems to be blocking the 'noindex' meta tag for published forms and therefore some forms have been indexed by search engines.