### PR TITLE
Api submission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,6 @@ workflows:
             branches:
               only:
                 - main
-                - api-submission
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -249,23 +248,23 @@ workflows:
           context: *moj-forms-context
           requires:
             - deploy_to_test_dev
-      #       - deploy_to_test_production
-      # - build_and_push_image_live:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      # - deploy_to_live_dev:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      # - deploy_to_live_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      # - smoke_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+            - deploy_to_test_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,7 @@ workflows:
             branches:
               only:
                 - main
+                - api-submission
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -248,23 +249,23 @@ workflows:
           context: *moj-forms-context
           requires:
             - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      #       - deploy_to_test_production
+      # - build_and_push_image_live:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      # - deploy_to_live_dev:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - deploy_to_live_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - smoke_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -46,7 +46,7 @@ module Platform
     end
 
     def actions
-      [email_action, csv_action, confirmation_email_action].compact
+      [email_action, csv_action, confirmation_email_action, json_action].compact
     end
 
     def pages

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -228,7 +228,7 @@ module Platform
       {
         kind: 'json',
         url: ENV['SERVICE_OUTPUT_JSON_ENDPOINT'],
-        encryption_key: ENV['SERVICE_OUTPUT_JSON_KEY']
+        key: ENV['SERVICE_OUTPUT_JSON_KEY']
       }
     end
   end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -6,7 +6,6 @@ module Platform
     CSV = 'csv'.freeze
     EMAIL = 'email'.freeze
     DEFAULT_EMAIL_ADDRESS = 'no-reply-moj-forms@digital.justice.gov.uk'.freeze
-    JSON = 'json'.freeze
 
     def initialize(service:, user_data:, session:)
       @service = service
@@ -227,7 +226,7 @@ module Platform
       return if ENV['SERVICE_OUTPUT_JSON_ENDPOINT'].blank? || ENV['SERVICE_OUTPUT_JSON_KEY'].blank?
 
       {
-        kind: JSON,
+        kind: 'json',
         url: ENV['SERVICE_OUTPUT_JSON_ENDPOINT'],
         encryption_key: ENV['SERVICE_OUTPUT_JSON_KEY']
       }

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -229,7 +229,6 @@ module Platform
       {
         kind: JSON,
         url: ENV['SERVICE_OUTPUT_JSON_ENDPOINT'],
-        data_url: 'some field',
         encryption_key: ENV['SERVICE_OUTPUT_JSON_KEY']
       }
     end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -6,6 +6,7 @@ module Platform
     CSV = 'csv'.freeze
     EMAIL = 'email'.freeze
     DEFAULT_EMAIL_ADDRESS = 'no-reply-moj-forms@digital.justice.gov.uk'.freeze
+    JSON = 'json'.freeze
 
     def initialize(service:, user_data:, session:)
       @service = service
@@ -220,6 +221,17 @@ module Platform
 
     def default_email_from
       @default_email_from ||= "#{service_name} <#{DEFAULT_EMAIL_ADDRESS}>"
+    end
+
+    def json_action
+      return if ENV['SERVICE_OUTPUT_JSON_ENDPOINT'].blank? || ENV['SERVICE_OUTPUT_JSON_KEY'].blank?
+
+      {
+        kind: JSON,
+        url: ENV['SERVICE_OUTPUT_JSON_ENDPOINT'],
+        data_url: 'some field',
+        encryption_key: ENV['SERVICE_OUTPUT_JSON_KEY']
+      }
     end
   end
 end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -656,13 +656,13 @@ RSpec.describe Platform::SubmitterPayload do
 
     context 'when json api submission is required' do
       let(:api_endpoint_url) { 'https://json-endpoint.url' }
-      let(:api_endpoint_key) { 'encryption-key' }
+      let(:api_endpoint_key) { 'json-key' }
       let(:expected_actions) do
         [
           {
             kind: 'json',
             url: api_endpoint_url,
-            encryption_key: api_endpoint_key
+            key: api_endpoint_key
           }
         ]
       end

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -653,6 +653,29 @@ RSpec.describe Platform::SubmitterPayload do
         expect(subject.actions).to eq(expected_actions)
       end
     end
+
+    context 'when json api submission is required' do
+      let(:api_endpoint_url) { 'https://json-endpoint.url' }
+      let(:api_endpoint_key) { 'encryption-key' }
+      let(:expected_actions) do
+        [
+          {
+            kind: 'email',
+            url: api_endpoint_url,
+            key: api_endpoint_key
+          }
+        ]
+      end
+
+      before do
+        allow(ENV).to receive(:[]).with('SERVICE_OUTPUT_JSON_ENDPOINT').and_return(api_endpoint_url)
+        allow(ENV).to receive(:[]).with('SERVICE_OUTPUT_JSON_KEY').and_return(api_endpoint_key)
+      end
+
+      it 'should return just the email action' do
+        expect(subject.actions).to eq(expected_actions)
+      end
+    end
   end
 
   describe '#concatenation_with_reference_number' do

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -660,9 +660,9 @@ RSpec.describe Platform::SubmitterPayload do
       let(:expected_actions) do
         [
           {
-            kind: 'email',
+            kind: 'json',
             url: api_endpoint_url,
-            key: api_endpoint_key
+            encryption_key: api_endpoint_key
           }
         ]
       end


### PR DESCRIPTION
[Trello](https://trello.com/c/BdGST0MB/3393-api-submission-submitter-update)


## Context

For the migration we need to implement the API submission. This PR is for the runner, that get the environment variables sent by the editor at publishing and send it to the submitter

## Implementation
We just add the json action, that consist in an endpoint url and a key.

## Testing
Unit tests and doesn't break acceptance tests see [deployment](https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner/6371/workflows/50aa4886-04c6-446d-8686-5fdcf8b251ac/jobs/18905)
Further work to update acceptance tests will be done in [ticket](https://trello.com/c/gjuaAuBf/3396-api-submission-acceptance-tests)