### PR TITLE
Add userdata to confirmation email alt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,50 +222,49 @@ workflows:
           context: *moj-forms-context
           requires:
             - build
-      # - test:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - build
+      - test:
+          context: *moj-forms-context
+          requires:
+            - build
       - build_and_push_image_test:
           context: *moj-forms-context
           requires:
             - lint
             - security
-            # - test
+            - test
           filters:
             branches:
               only:
                 - main
-                - add-userdata-to-email-body
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      # - deploy_to_test_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - build_and_push_image_test
-      # - acceptance_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_test_dev
-      #       - deploy_to_test_production
-      # - build_and_push_image_live:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      # - deploy_to_live_dev:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      # - deploy_to_live_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      # - smoke_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+      - deploy_to_test_production:
+          context: *moj-forms-context
+          requires:
+            - build_and_push_image_test
+      - acceptance_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_test_dev
+            - deploy_to_test_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,49 +222,50 @@ workflows:
           context: *moj-forms-context
           requires:
             - build
-      - test:
-          context: *moj-forms-context
-          requires:
-            - build
+      # - test:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - build
       - build_and_push_image_test:
           context: *moj-forms-context
           requires:
             - lint
             - security
-            - test
+            # - test
           filters:
             branches:
               only:
                 - main
+                - add-userdata-to-email-body
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      - deploy_to_test_production:
-          context: *moj-forms-context
-          requires:
-            - build_and_push_image_test
-      - acceptance_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - deploy_to_test_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - build_and_push_image_test
+      # - acceptance_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_test_dev
+      #       - deploy_to_test_production
+      # - build_and_push_image_live:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      # - deploy_to_live_dev:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - deploy_to_live_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - smoke_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -3,6 +3,29 @@ module ConfirmationEmailHelper
   include ActionView::Helpers::TagHelper
   include ActionView::Helpers::TextHelper
 
+  STYLES = {
+    heading: {
+      font_size: '20px',
+      font_weight: 'bold',
+      padding_top: '20px',
+      padding_bottom: '15px'
+    },
+    cell: {
+      width: '50%',
+      padding_top: '5px',
+      padding_bottom: '5px',
+      border_bottom: '1px solid #C4C4C4',
+      vertical_align: 'top'
+    },
+    question: {
+      font_weight: 'bold',
+      padding_right: '5px'
+    },
+    answer: {
+      padding_left: '5px'
+    }
+  }.freeze
+
   def answers_html(pages)
     table_heading + answers_table(pages)
   end
@@ -13,7 +36,7 @@ module ConfirmationEmailHelper
 
   def heading_row(content)
     tag.tr do
-      tag.td colspan: 2, style: inline_style_string(heading_styles) do
+      tag.td colspan: 2, style: heading_styles do
         content
       end
     end
@@ -25,7 +48,7 @@ module ConfirmationEmailHelper
         concat(heading_row(page[:heading])) if page[:heading].present?
 
         page[:answers].collect { |answer|
-          concat answer_row(answer[:field_name], human_value(answer[:answer]))
+          concat answer_row(answer[:field_name], answer[:answer])
         }.join.html_safe
       }.join.html_safe
     end
@@ -36,49 +59,26 @@ module ConfirmationEmailHelper
   end
 
   def question_cell(content)
-    tag.td(content, style: inline_style_string(cell_styles.merge(question_styles)))
+    tag.td(content, style: question_styles)
   end
 
   def answer_cell(content)
-    tag.td(content, style: inline_style_string(cell_styles.merge(answer_styles)))
+    tag.td(content, style: answer_styles)
   end
 
-  def human_value(answer)
-    answer.is_a?(Array) ? answer.join("\n\n") : answer
+  def heading_styles
+    inline_style_string(STYLES[:heading])
+  end
+
+  def question_styles
+    inline_style_string(STYLES[:cell].merge(STYLES[:question]))
+  end
+
+  def answer_styles
+    inline_style_string(STYLES[:cell].merge(STYLES[:answer]))
   end
 
   def inline_style_string(attributes)
     attributes.reduce('') { |str, (prop, val)| str + "#{prop.to_s.dasherize}: #{val}; " }.rstrip
-  end
-
-  def heading_styles
-    {
-      font_size: '20px',
-      padding_top: '15px',
-      padding_bottom: '15px'
-    }
-  end
-
-  def question_styles
-    {
-      font_weight: 'bold',
-      padding_right: '5px'
-    }
-  end
-
-  def answer_styles
-    {
-      padding_left: '5px'
-    }
-  end
-
-  def cell_styles
-    {
-      width: '50%',
-      padding_top: '5px',
-      padding_bottom: '5px',
-      border_bottom: '1px solid #C4C4C4',
-      vertical_align: 'top'
-    }
   end
 end

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -1,0 +1,45 @@
+module ConfirmationEmailHelper
+  include ActionView::Context
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::TextHelper
+
+  def answers_html(pages)
+    table_heading + answers_table(pages)
+  end
+
+  def table_heading
+    tag.h2('Your answers')
+  end
+
+  def heading_row(content)
+    tag.tr(tag.td(content, colspan: 2, style: 'font-weight: bold; font-size: 24px;'))
+  end
+
+  def answers_table(pages)
+    tag.table do
+      pages.collect { |page|
+        concat(heading_row(page[:heading])) if page[:heading].present?
+
+        page[:answers].collect { |answer|
+          concat answer_row(answer[:field_name], human_value(answer[:answer]))
+        }.join.html_safe
+      }.join.html_safe
+    end
+  end
+
+  def answer_row(question, answer)
+    tag.tr(question_cell(question) + answer_cell(answer))
+  end
+
+  def question_cell(content)
+    tag.td(content, style: 'font-weight: bold;')
+  end
+
+  def answer_cell(content)
+    tag.td(content, style: '')
+  end
+
+  def human_value(answer)
+    answer.is_a?(Array) ? answer.join("\n\n") : answer
+  end
+end

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -54,7 +54,7 @@ module ConfirmationEmailHelper
       pages.collect { |page|
         concat(heading_row(page[:heading])) if page[:heading].present?
         page[:answers].each_with_index.collect { |answer, index|
-          if last_answer_on_multiquestion_page(page[:answers], index)
+          if multiquestion_page?(page[:answers])
             concat answer_row(question: answer[:field_name], answer: answer[:answer])
             previous_page_was_multiquestion = true
           else
@@ -104,7 +104,7 @@ module ConfirmationEmailHelper
     attributes.reduce('') { |str, (prop, val)| str + "#{prop.to_s.dasherize}: #{val}; " }.rstrip
   end
 
-  def last_answer_on_multiquestion_page(answers, index)
-    answers.size > 1 && index == answers.size - 1
+  def multiquestion_page?(answers)
+    answers.size > 1
   end
 end

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -53,7 +53,7 @@ module ConfirmationEmailHelper
       previous_page_was_multiquestion = false
       pages.collect { |page|
         concat(heading_row(page[:heading])) if page[:heading].present?
-        page[:answers].each_with_index.collect { |answer, index|
+        page[:answers].each.collect { |answer|
           if multiquestion_page?(page[:answers])
             concat answer_row(question: answer[:field_name], answer: answer[:answer])
             previous_page_was_multiquestion = true

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -36,8 +36,8 @@ module ConfirmationEmailHelper
 
   def heading_row(content)
     tag.tr do
-      tag.td colspan: 2, style: heading_styles do
-        content
+      tag.td colspan: 2 do
+        tag.h3 content
       end
     end
   end

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -12,7 +12,11 @@ module ConfirmationEmailHelper
   end
 
   def heading_row(content)
-    tag.tr(tag.td(content, colspan: 2, style: 'font-weight: bold; font-size: 24px;'))
+    tag.tr do
+      tag.td colspan: 2, style: inline_style_string(heading_styles) do
+        content
+      end
+    end
   end
 
   def answers_table(pages)
@@ -32,14 +36,49 @@ module ConfirmationEmailHelper
   end
 
   def question_cell(content)
-    tag.td(content, style: 'font-weight: bold;')
+    tag.td(content, style: inline_style_string(cell_styles.merge(question_styles)))
   end
 
   def answer_cell(content)
-    tag.td(content, style: '')
+    tag.td(content, style: inline_style_string(cell_styles.merge(answer_styles)))
   end
 
   def human_value(answer)
     answer.is_a?(Array) ? answer.join("\n\n") : answer
+  end
+
+  def inline_style_string(attributes)
+    attributes.reduce('') { |str, (prop, val)| str + "#{prop.to_s.dasherize}: #{val}; " }.rstrip
+  end
+
+  def heading_styles
+    {
+      font_size: '20px',
+      padding_top: '15px',
+      padding_bottom: '15px'
+    }
+  end
+
+  def question_styles
+    {
+      font_weight: 'bold',
+      padding_right: '5px'
+    }
+  end
+
+  def answer_styles
+    {
+      padding_left: '5px'
+    }
+  end
+
+  def cell_styles
+    {
+      width: '50%',
+      padding_top: '5px',
+      padding_bottom: '5px',
+      border_bottom: '1px solid #C4C4C4',
+      vertical_align: 'top'
+    }
   end
 end

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -26,8 +26,8 @@ module ConfirmationEmailHelper
       answer_cell: {
         padding_left: '5px'
       },
-      last_row_cell: {
-        padding_bottom: '20px'
+      first_row_cell: {
+        padding_top: '20px'
       }
     }.freeze
   end
@@ -50,30 +50,32 @@ module ConfirmationEmailHelper
 
   def answers_table(pages)
     tag.table do
+      previous_page_was_multiquestion = false
       pages.collect { |page|
         concat(heading_row(page[:heading])) if page[:heading].present?
-
         page[:answers].each_with_index.collect { |answer, index|
           if last_answer_on_multiquestion_page(page[:answers], index)
-            concat answer_row(question: answer[:field_name], answer: answer[:answer], last_row: true)
-          else
             concat answer_row(question: answer[:field_name], answer: answer[:answer])
+            previous_page_was_multiquestion = true
+          else
+            concat answer_row(question: answer[:field_name], answer: answer[:answer], first_row: previous_page_was_multiquestion)
+            previous_page_was_multiquestion = false
           end
         }.join.html_safe
       }.join.html_safe
     end
   end
 
-  def answer_row(question:, answer:, last_row: false)
-    tag.tr(question_cell(content: question, last_row:) + answer_cell(content: answer, last_row:))
+  def answer_row(question:, answer:, first_row: false)
+    tag.tr(question_cell(content: question, first_row:) + answer_cell(content: answer, first_row:))
   end
 
-  def question_cell(content:, last_row: false)
-    tag.td(content, style: question_cell_styles(last_row:))
+  def question_cell(content:, first_row: false)
+    tag.td(content, style: question_cell_styles(first_row:))
   end
 
-  def answer_cell(content:, last_row: false)
-    tag.td(content, style: answer_cell_styles(last_row:))
+  def answer_cell(content:, first_row: false)
+    tag.td(content, style: answer_cell_styles(first_row:))
   end
 
   def heading_row_styles
@@ -84,15 +86,15 @@ module ConfirmationEmailHelper
     inline_style_string(styles[:h3])
   end
 
-  def question_cell_styles(last_row: false)
+  def question_cell_styles(first_row: false)
     question_styles = styles[:cell].merge(styles[:question_cell])
-    question_styles.merge!(styles[:last_row_cell]) if last_row
+    question_styles.merge!(styles[:first_row_cell]) if first_row
     inline_style_string(question_styles)
   end
 
-  def answer_cell_styles(last_row: false)
+  def answer_cell_styles(first_row: false)
     answer_styles = styles[:cell].merge(styles[:answer_cell])
-    answer_styles.merge!(styles[:last_row_cell]) if last_row
+    answer_styles.merge!(styles[:first_row_cell]) if first_row
     inline_style_string(answer_styles)
   end
 

--- a/app/helpers/confirmation_email_helper.rb
+++ b/app/helpers/confirmation_email_helper.rb
@@ -5,8 +5,6 @@ module ConfirmationEmailHelper
 
   STYLES = {
     heading: {
-      font_size: '20px',
-      font_weight: 'bold',
       padding_top: '20px',
       padding_bottom: '15px'
     },
@@ -36,8 +34,8 @@ module ConfirmationEmailHelper
 
   def heading_row(content)
     tag.tr do
-      tag.td colspan: 2 do
-        tag.h3 content
+      tag.td colspan: 2, style: heading_styles do
+        tag.h3 content, style: 'margin: 0 !important;'
       end
     end
   end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -1,9 +1,7 @@
 module Platform
   class SubmitterPayload
     include Platform::Connection
-    include ActionView::Context
-    include ActionView::Helpers::TagHelper
-    include ActionView::Helpers::TextHelper
+    include ConfirmationEmailHelper
     attr_reader :service, :user_data, :session
 
     CSV = 'csv'.freeze
@@ -98,20 +96,6 @@ module Platform
       end
     end
 
-    def confirmation_email_answers_html
-      tag.h2('Your answers') +
-        tag.table do
-          pages.collect { |page|
-            concat(tag.tr(tag.td(page[:heading], colspan: 2))) if page[:heading].present?
-            page[:answers].collect { |answer|
-              concat(
-                tag.tr(tag.td(answer[:field_name]) + tag.td(human_value(answer[:answer])))
-              )
-            }.join.html_safe
-          }.join.html_safe
-        end
-    end
-
     private
 
     def email_action
@@ -150,7 +134,7 @@ module Platform
         to: confirmation_email_answer,
         from: confirmation_email_reply_to,
         subject: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_SUBJECT']),
-        email_body: inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']) + confirmation_email_answers_html,
+        email_body: inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']) + answers_html(pages),
         include_attachments: true,
         include_pdf: true
       }

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -236,9 +236,5 @@ module Platform
         key: ENV['SERVICE_OUTPUT_JSON_KEY']
       }
     end
-
-    def human_value(answer)
-      answer.is_a?(Array) ? answer.join("\n\n") : answer
-    end
   end
 end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -134,10 +134,14 @@ module Platform
         to: confirmation_email_answer,
         from: confirmation_email_reply_to,
         subject: concatenation_with_reference_number(ENV['CONFIRMATION_EMAIL_SUBJECT']),
-        email_body: inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']) + answers_html(pages),
+        email_body: confirmation_email_body,
         include_attachments: true,
         include_pdf: true
       }
+    end
+
+    def confirmation_email_body
+      inject_reference_payment_content(ENV['CONFIRMATION_EMAIL_BODY']) + answers_html(pages)
     end
 
     def strip_content_components(components)

--- a/spec/helpers/confirmation_email_helper_spec.rb
+++ b/spec/helpers/confirmation_email_helper_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe ConfirmationEmailHelper do
+  let(:pages) do
+    [
+      {
+        answers: [
+          { field_name: 'Question 1', answer: 'Answer 1' },
+          { field_name: 'Question 2', answer: 'Answer 2' }
+        ]
+      },
+      {
+        heading: 'Page Heading',
+        answers: [
+          { field_name: 'Question 3', answer: 'Answer 3' },
+          { field_name: 'Question 4', answer: 'Answer 4' }
+        ]
+      }
+    ]
+  end
+
+  describe '#table_header'
+  it 'should build the h2' do
+    expect(helper.table_heading).to eql '<h2>Your answers</h2>'
+  end
+
+  describe '#inline_style_string' do
+    let(:styles) { { font_weight: 'bold', font_size: '24px' } }
+
+    it 'should genrate a style string from hash' do
+      expect(helper.inline_style_string(styles)).to eql 'font-weight: bold; font-size: 24px;'
+    end
+  end
+
+  describe '#human_value' do
+    let(:arry) { %w[one two three] }
+
+    it 'should join array values with newlines' do
+      expect(helper.human_value(arry)).to eql "one\n\ntwo\n\nthree"
+    end
+
+    it 'should pass through string values' do
+      expect(helper.human_value('string')).to eql 'string'
+    end
+  end
+
+  describe '#answer_cell' do
+    it 'generates the table cell html with merged styles' do
+      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
+      allow(helper).to receive(:answer_styles).and_return({ font_size: '100px' })
+
+      expect(helper.answer_cell('answer')).to eql '<td style="color: red; font-size: 100px;">answer</td>'
+    end
+  end
+
+  describe '#question_cell' do
+    it 'generates the table cell html with merged styles' do
+      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
+      allow(helper).to receive(:question_styles).and_return({ font_size: '100px' })
+
+      expect(helper.question_cell('question')).to eql '<td style="color: red; font-size: 100px;">question</td>'
+    end
+  end
+
+  describe '#answer_row' do
+    it 'generates the table row html with merged styles' do
+      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
+      allow(helper).to receive(:answer_styles).and_return({ font_size: '100px' })
+      allow(helper).to receive(:question_styles).and_return({ width: '50%' })
+
+      expect(helper.answer_row('question', 'answer')).to eql '<tr><td style="color: red; width: 50%;">question</td><td style="color: red; font-size: 100px;">answer</td></tr>'
+    end
+  end
+
+  describe '#answers_table' do
+    let(:q1) { '<td style="color: red; width: 50%;">Question 1</td>' }
+    let(:a1) { '<td style="color: red; font-size: 100px;">Answer 1</td>' }
+    let(:q2) { '<td style="color: red; width: 50%;">Question 2</td>' }
+    let(:a2) { '<td style="color: red; font-size: 100px;">Answer 2</td>' }
+    let(:heading) { '<td colspan="2" style="color: blue;">Page Heading</td>' }
+    let(:q3) { '<td style="color: red; width: 50%;">Question 3</td>' }
+    let(:a3) { '<td style="color: red; font-size: 100px;">Answer 3</td>' }
+    let(:q4) { '<td style="color: red; width: 50%;">Question 4</td>' }
+    let(:a4) { '<td style="color: red; font-size: 100px;">Answer 4</td>' }
+
+    it 'generates the table html' do
+      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
+      allow(helper).to receive(:answer_styles).and_return({ font_size: '100px' })
+      allow(helper).to receive(:question_styles).and_return({ width: '50%' })
+      allow(helper).to receive(:heading_styles).and_return({ color: 'blue' })
+      # "<table>
+      #       <tr>
+      #       <td style=\"color: red; width: 50%;\">Question 1</td>
+      #       <td style=\"color: red; font-size: 100px;\">Answer 1</td>
+      #       </tr>
+      #       <tr>
+      #       <td style=\"color: red; width: 50%;\">Question 2</td>
+      #       <td style=\"color: red; font-size: 100px;\">Answer 2</td>
+      #       </tr>
+      #       <tr>
+      #       <td colspan=\"2\" style=\"color: blue;\">Page Heading</td>
+      #       </tr>
+      #       <tr>
+      #       <td style=\"color: red; width: 50%;\">Question 3</td>
+      #       <td style=\"color: red; font-size: 100px;\">Answer 3</td>
+      #       </tr>
+      #       <tr>
+      #       <td style=\"color: red; width: 50%;\">Question 4</td>
+      #       <td style=\"color: red; font-size: 100px;\">Answer 4</td>
+      #       </tr>
+      #       </table>"
+      #       byebug
+      expect(helper.answers_table(pages)).to eql "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
+    end
+  end
+end

--- a/spec/helpers/confirmation_email_helper_spec.rb
+++ b/spec/helpers/confirmation_email_helper_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ConfirmationEmailHelper do
       },
       {
         answers: [
-          { field_name: 'Question 1', answer: 'Answer 1' }
+          { field_name: 'Question 5', answer: 'Answer 5' }
         ]
       }
     ]
@@ -38,7 +38,7 @@ RSpec.describe ConfirmationEmailHelper do
   end
 
   before do
-    # allow(helper).to receive(:styles).and_return(test_styles)
+    allow(helper).to receive(:styles).and_return(test_styles)
   end
 
   describe '#inline_style_string' do
@@ -53,20 +53,16 @@ RSpec.describe ConfirmationEmailHelper do
     end
   end
 
-  describe '#last_answer_on_multiquestion_page' do
+  describe '#multiquestion_page?' do
     let(:single_q_page) { %w[answer] }
     let(:multi_q_page) { %w[answer1 answer2] }
 
     it 'is false for single question pages' do
-      expect(helper.last_answer_on_multiquestion_page(single_q_page, 0)).to be false
+      expect(helper.multiquestion_page?(single_q_page)).to be false
     end
 
-    it 'is false when not the last answer on a multiquestion page' do
-      expect(helper.last_answer_on_multiquestion_page(multi_q_page, 0)).to be false
-    end
-
-    it 'is true when the last answer on a multiquestion page' do
-      expect(helper.last_answer_on_multiquestion_page(multi_q_page, 1)).to be true
+    it 'is true when a multiquestion page' do
+      expect(helper.multiquestion_page?(multi_q_page)).to be true
     end
   end
 
@@ -75,7 +71,7 @@ RSpec.describe ConfirmationEmailHelper do
       {
         cell: { width: '50%', padding_bottom: '10px' },
         answer_cell: { font_size: '100px' },
-        last_row_cell: { padding_bottom: '20px' }
+        first_row_cell: { padding_bottom: '20px' }
       }
     end
 
@@ -83,8 +79,8 @@ RSpec.describe ConfirmationEmailHelper do
       expect(helper.answer_cell_styles).to eql 'width: 50%; padding-bottom: 10px; font-size: 100px;'
     end
 
-    it 'inlcudes the last row cell styles when last_row=true' do
-      expect(helper.answer_cell_styles(last_row: true)).to eql 'width: 50%; padding-bottom: 20px; font-size: 100px;'
+    it 'inlcudes the last row cell styles when first_row=true' do
+      expect(helper.answer_cell_styles(first_row: true)).to eql 'width: 50%; padding-bottom: 20px; font-size: 100px;'
     end
   end
 
@@ -93,7 +89,7 @@ RSpec.describe ConfirmationEmailHelper do
       {
         cell: { width: '50%', padding_bottom: '10px' },
         question_cell: { font_size: '100px' },
-        last_row_cell: { padding_bottom: '20px' }
+        first_row_cell: { padding_bottom: '20px' }
       }
     end
 
@@ -101,8 +97,8 @@ RSpec.describe ConfirmationEmailHelper do
       expect(helper.question_cell_styles).to eql 'width: 50%; padding-bottom: 10px; font-size: 100px;'
     end
 
-    it 'inlcudes the last row cell styles when last_row=true' do
-      expect(helper.question_cell_styles(last_row: true)).to eql 'width: 50%; padding-bottom: 20px; font-size: 100px;'
+    it 'inlcudes the last row cell styles when first_row=true' do
+      expect(helper.question_cell_styles(first_row: true)).to eql 'width: 50%; padding-bottom: 20px; font-size: 100px;'
     end
   end
 
@@ -133,7 +129,7 @@ RSpec.describe ConfirmationEmailHelper do
         cell: { width: '50%' },
         question_cell: { color: 'red' },
         answer_cell: { color: 'blue' },
-        last_row_cell: { padding_bottom: '20px' }
+        first_row_cell: { padding_bottom: '20px' }
       }
     end
     it 'generates the table row html with merged styles' do
@@ -141,7 +137,7 @@ RSpec.describe ConfirmationEmailHelper do
     end
 
     it 'generates the last table row html with merged styles' do
-      expect(helper.answer_row(question: 'question', answer: 'answer', last_row: true)).to eql '<tr><td style="width: 50%; color: red; padding-bottom: 20px;">question</td><td style="width: 50%; color: blue; padding-bottom: 20px;">answer</td></tr>'
+      expect(helper.answer_row(question: 'question', answer: 'answer', first_row: true)).to eql '<tr><td style="width: 50%; color: red; padding-bottom: 20px;">question</td><td style="width: 50%; color: blue; padding-bottom: 20px;">answer</td></tr>'
     end
   end
 
@@ -165,26 +161,30 @@ RSpec.describe ConfirmationEmailHelper do
         cell: { color: 'red' },
         question_cell: { width: '50%' },
         answer_cell: { font_size: '100px' },
-        last_row_cell: { padding_bottom: '20px' }
+        first_row_cell: { padding_top: '20px' }
       }
     end
 
     let(:q1) { '<td style="color: red; width: 50%;">Question 1</td>' }
     let(:a1) { '<td style="color: red; font-size: 100px;">Answer 1</td>' }
-    let(:q2) { '<td style="color: red; width: 50%; padding-bottom: 20px;">Question 2</td>' }
-    let(:a2) { '<td style="color: red; font-size: 100px; padding-bottom: 20px;">Answer 2</td>' }
+    let(:q2) { '<td style="color: red; width: 50%;">Question 2</td>' }
+    let(:a2) { '<td style="color: red; font-size: 100px;">Answer 2</td>' }
     let(:heading) { '<td colspan="2" style="color: green;"><h3 style="color: blue;">Page Heading</h3></td>' }
     let(:q3) { '<td style="color: red; width: 50%;">Question 3</td>' }
     let(:a3) { '<td style="color: red; font-size: 100px;">Answer 3</td>' }
-    let(:q4) { '<td style="color: red; width: 50%; padding-bottom: 20px;">Question 4</td>' }
-    let(:a4) { '<td style="color: red; font-size: 100px; padding-bottom: 20px;">Answer 4</td>' }
+    let(:q4) { '<td style="color: red; width: 50%;">Question 4</td>' }
+    let(:a4) { '<td style="color: red; font-size: 100px;">Answer 4</td>' }
+    let(:q5) { '<td style="color: red; width: 50%; padding-top: 20px;">Question 5</td>' }
+    let(:a5) { '<td style="color: red; font-size: 100px; padding-top: 20px;">Answer 5</td>' }
+
+    let(:table_html)  { "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr><tr>#{q5}#{a5}</tr></table>"}
 
     it 'generates the table html' do
-      expect(helper.answers_table(pages)).to eql "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
+      expect(helper.answers_table(pages)).to eql table_html
     end
 
     it 'generates the table html' do
-      expect(helper.answers_html(pages)).to eql "<h2>Your answers</h2><table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
+      expect(helper.answers_html(pages)).to eql "<h2>Your answers</h2>#{table_html}"
     end
   end
 end

--- a/spec/helpers/confirmation_email_helper_spec.rb
+++ b/spec/helpers/confirmation_email_helper_spec.rb
@@ -3,7 +3,11 @@ RSpec.describe ConfirmationEmailHelper do
     [
       {
         answers: [
-          { field_name: 'Question 1', answer: 'Answer 1' },
+          { field_name: 'Question 1', answer: 'Answer 1' }
+        ]
+      },
+      {
+        answers: [
           { field_name: 'Question 2', answer: 'Answer 2' }
         ]
       },
@@ -12,6 +16,11 @@ RSpec.describe ConfirmationEmailHelper do
         answers: [
           { field_name: 'Question 3', answer: 'Answer 3' },
           { field_name: 'Question 4', answer: 'Answer 4' }
+        ]
+      },
+      {
+        answers: [
+          { field_name: 'Question 1', answer: 'Answer 1' }
         ]
       }
     ]
@@ -24,12 +33,12 @@ RSpec.describe ConfirmationEmailHelper do
       cell: { width: '50%' },
       question_cell: { color: 'red ' },
       answer_cell: { font_size: '100px' },
-      last_row_cell: { padding_bottom: '20px' }
+      first_row_cell: { padding_bottom: '20px' }
     }
   end
 
   before do
-    allow(helper).to receive(:styles).and_return(test_styles)
+    # allow(helper).to receive(:styles).and_return(test_styles)
   end
 
   describe '#inline_style_string' do

--- a/spec/helpers/confirmation_email_helper_spec.rb
+++ b/spec/helpers/confirmation_email_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ConfirmationEmailHelper do
     ]
   end
 
-  describe '#table_header'
+  describe '#table_heading'
   it 'should build the h2' do
     expect(helper.table_heading).to eql '<h2>Your answers</h2>'
   end
@@ -30,22 +30,9 @@ RSpec.describe ConfirmationEmailHelper do
     end
   end
 
-  describe '#human_value' do
-    let(:arry) { %w[one two three] }
-
-    it 'should join array values with newlines' do
-      expect(helper.human_value(arry)).to eql "one\n\ntwo\n\nthree"
-    end
-
-    it 'should pass through string values' do
-      expect(helper.human_value('string')).to eql 'string'
-    end
-  end
-
   describe '#answer_cell' do
     it 'generates the table cell html with merged styles' do
-      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
-      allow(helper).to receive(:answer_styles).and_return({ font_size: '100px' })
+      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
 
       expect(helper.answer_cell('answer')).to eql '<td style="color: red; font-size: 100px;">answer</td>'
     end
@@ -53,20 +40,26 @@ RSpec.describe ConfirmationEmailHelper do
 
   describe '#question_cell' do
     it 'generates the table cell html with merged styles' do
-      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
-      allow(helper).to receive(:question_styles).and_return({ font_size: '100px' })
+      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
 
-      expect(helper.question_cell('question')).to eql '<td style="color: red; font-size: 100px;">question</td>'
+      expect(helper.question_cell('question')).to eql '<td style="color: red; width: 50%;">question</td>'
     end
   end
 
   describe '#answer_row' do
     it 'generates the table row html with merged styles' do
-      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
-      allow(helper).to receive(:answer_styles).and_return({ font_size: '100px' })
-      allow(helper).to receive(:question_styles).and_return({ width: '50%' })
+      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
+      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
 
       expect(helper.answer_row('question', 'answer')).to eql '<tr><td style="color: red; width: 50%;">question</td><td style="color: red; font-size: 100px;">answer</td></tr>'
+    end
+  end
+
+  describe '#heading_row' do
+    it 'generates the heading row html' do
+      allow(helper).to receive(:heading_styles).and_return('font-size: 20px;')
+
+      expect(helper.heading_row('Heading')).to eql '<tr><td colspan="2" style="font-size: 20px;">Heading</td></tr>'
     end
   end
 
@@ -82,33 +75,31 @@ RSpec.describe ConfirmationEmailHelper do
     let(:a4) { '<td style="color: red; font-size: 100px;">Answer 4</td>' }
 
     it 'generates the table html' do
-      allow(helper).to receive(:cell_styles).and_return({ color: 'red' })
-      allow(helper).to receive(:answer_styles).and_return({ font_size: '100px' })
-      allow(helper).to receive(:question_styles).and_return({ width: '50%' })
-      allow(helper).to receive(:heading_styles).and_return({ color: 'blue' })
-      # "<table>
-      #       <tr>
-      #       <td style=\"color: red; width: 50%;\">Question 1</td>
-      #       <td style=\"color: red; font-size: 100px;\">Answer 1</td>
-      #       </tr>
-      #       <tr>
-      #       <td style=\"color: red; width: 50%;\">Question 2</td>
-      #       <td style=\"color: red; font-size: 100px;\">Answer 2</td>
-      #       </tr>
-      #       <tr>
-      #       <td colspan=\"2\" style=\"color: blue;\">Page Heading</td>
-      #       </tr>
-      #       <tr>
-      #       <td style=\"color: red; width: 50%;\">Question 3</td>
-      #       <td style=\"color: red; font-size: 100px;\">Answer 3</td>
-      #       </tr>
-      #       <tr>
-      #       <td style=\"color: red; width: 50%;\">Question 4</td>
-      #       <td style=\"color: red; font-size: 100px;\">Answer 4</td>
-      #       </tr>
-      #       </table>"
-      #       byebug
+      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
+      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
+      allow(helper).to receive(:heading_styles).and_return('color: blue;')
+
       expect(helper.answers_table(pages)).to eql "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
+    end
+  end
+
+  describe '#answers_html' do
+    let(:q1) { '<td style="color: red; width: 50%;">Question 1</td>' }
+    let(:a1) { '<td style="color: red; font-size: 100px;">Answer 1</td>' }
+    let(:q2) { '<td style="color: red; width: 50%;">Question 2</td>' }
+    let(:a2) { '<td style="color: red; font-size: 100px;">Answer 2</td>' }
+    let(:heading) { '<td colspan="2" style="color: blue;">Page Heading</td>' }
+    let(:q3) { '<td style="color: red; width: 50%;">Question 3</td>' }
+    let(:a3) { '<td style="color: red; font-size: 100px;">Answer 3</td>' }
+    let(:q4) { '<td style="color: red; width: 50%;">Question 4</td>' }
+    let(:a4) { '<td style="color: red; font-size: 100px;">Answer 4</td>' }
+
+    it 'generates the table html' do
+      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
+      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
+      allow(helper).to receive(:heading_styles).and_return('color: blue;')
+
+      expect(helper.answers_html(pages)).to eql "<h2>Your answers</h2><table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
     end
   end
 end

--- a/spec/helpers/confirmation_email_helper_spec.rb
+++ b/spec/helpers/confirmation_email_helper_spec.rb
@@ -17,9 +17,19 @@ RSpec.describe ConfirmationEmailHelper do
     ]
   end
 
-  describe '#table_heading'
-  it 'should build the h2' do
-    expect(helper.table_heading).to eql '<h2>Your answers</h2>'
+  let(:test_styles) do
+    {
+      heading_row: { color: 'green' },
+      h3: { color: 'blue' },
+      cell: { width: '50%' },
+      question_cell: { color: 'red ' },
+      answer_cell: { font_size: '100px' },
+      last_row_cell: { padding_bottom: '20px' }
+    }
+  end
+
+  before do
+    allow(helper).to receive(:styles).and_return(test_styles)
   end
 
   describe '#inline_style_string' do
@@ -28,77 +38,143 @@ RSpec.describe ConfirmationEmailHelper do
     it 'should genrate a style string from hash' do
       expect(helper.inline_style_string(styles)).to eql 'font-weight: bold; font-size: 24px;'
     end
+
+    it 'should return empty string if not given a hash' do
+      expect(helper.inline_style_string('not a hash')).to eql ''
+    end
+  end
+
+  describe '#last_answer_on_multiquestion_page' do
+    let(:single_q_page) { %w[answer] }
+    let(:multi_q_page) { %w[answer1 answer2] }
+
+    it 'is false for single question pages' do
+      expect(helper.last_answer_on_multiquestion_page(single_q_page, 0)).to be false
+    end
+
+    it 'is false when not the last answer on a multiquestion page' do
+      expect(helper.last_answer_on_multiquestion_page(multi_q_page, 0)).to be false
+    end
+
+    it 'is true when the last answer on a multiquestion page' do
+      expect(helper.last_answer_on_multiquestion_page(multi_q_page, 1)).to be true
+    end
+  end
+
+  describe '#answer_cell_styles' do
+    let(:test_styles) do
+      {
+        cell: { width: '50%', padding_bottom: '10px' },
+        answer_cell: { font_size: '100px' },
+        last_row_cell: { padding_bottom: '20px' }
+      }
+    end
+
+    it 'merges the cell and answer cell styles' do
+      expect(helper.answer_cell_styles).to eql 'width: 50%; padding-bottom: 10px; font-size: 100px;'
+    end
+
+    it 'inlcudes the last row cell styles when last_row=true' do
+      expect(helper.answer_cell_styles(last_row: true)).to eql 'width: 50%; padding-bottom: 20px; font-size: 100px;'
+    end
+  end
+
+  describe '#question_cell_styles' do
+    let(:test_styles) do
+      {
+        cell: { width: '50%', padding_bottom: '10px' },
+        question_cell: { font_size: '100px' },
+        last_row_cell: { padding_bottom: '20px' }
+      }
+    end
+
+    it 'merges the cell and question cell styles' do
+      expect(helper.question_cell_styles).to eql 'width: 50%; padding-bottom: 10px; font-size: 100px;'
+    end
+
+    it 'inlcudes the last row cell styles when last_row=true' do
+      expect(helper.question_cell_styles(last_row: true)).to eql 'width: 50%; padding-bottom: 20px; font-size: 100px;'
+    end
+  end
+
+  describe '#table_heading' do
+    it 'should build the h2' do
+      expect(helper.table_heading).to eql '<h2>Your answers</h2>'
+    end
   end
 
   describe '#answer_cell' do
     it 'generates the table cell html with merged styles' do
-      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
-
-      expect(helper.answer_cell('answer')).to eql '<td style="color: red; font-size: 100px;">answer</td>'
+      allow(helper).to receive(:answer_cell_styles).and_return('color: red; width: 50%;')
+      expect(helper.answer_cell(content: 'answer')).to eql '<td style="color: red; width: 50%;">answer</td>'
     end
   end
 
   describe '#question_cell' do
     it 'generates the table cell html with merged styles' do
-      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
+      allow(helper).to receive(:question_cell_styles).and_return('color: red; width: 50%;')
 
-      expect(helper.question_cell('question')).to eql '<td style="color: red; width: 50%;">question</td>'
+      expect(helper.question_cell(content: 'question')).to eql '<td style="color: red; width: 50%;">question</td>'
     end
   end
 
   describe '#answer_row' do
+    let(:test_styles) do
+      {
+        cell: { width: '50%' },
+        question_cell: { color: 'red' },
+        answer_cell: { color: 'blue' },
+        last_row_cell: { padding_bottom: '20px' }
+      }
+    end
     it 'generates the table row html with merged styles' do
-      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
-      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
+      expect(helper.answer_row(question: 'question', answer: 'answer')).to eql '<tr><td style="width: 50%; color: red;">question</td><td style="width: 50%; color: blue;">answer</td></tr>'
+    end
 
-      expect(helper.answer_row('question', 'answer')).to eql '<tr><td style="color: red; width: 50%;">question</td><td style="color: red; font-size: 100px;">answer</td></tr>'
+    it 'generates the last table row html with merged styles' do
+      expect(helper.answer_row(question: 'question', answer: 'answer', last_row: true)).to eql '<tr><td style="width: 50%; color: red; padding-bottom: 20px;">question</td><td style="width: 50%; color: blue; padding-bottom: 20px;">answer</td></tr>'
     end
   end
 
   describe '#heading_row' do
+    let(:test_styles) do
+      {
+        heading_row: { color: 'green' },
+        h3: { color: 'blue' }
+      }
+    end
     it 'generates the heading row html' do
-      allow(helper).to receive(:heading_styles).and_return('font-size: 20px;')
-
-      expect(helper.heading_row('Heading')).to eql '<tr><td colspan="2" style="font-size: 20px;">Heading</td></tr>'
+      expect(helper.heading_row('Heading')).to eql '<tr><td colspan="2" style="color: green;"><h3 style="color: blue;">Heading</h3></td></tr>'
     end
   end
 
-  describe '#answers_table' do
+  describe '#answers_table and #answers_html' do
+    let(:test_styles) do
+      {
+        heading_row: { color: 'green' },
+        h3: { color: 'blue' },
+        cell: { color: 'red' },
+        question_cell: { width: '50%' },
+        answer_cell: { font_size: '100px' },
+        last_row_cell: { padding_bottom: '20px' }
+      }
+    end
+
     let(:q1) { '<td style="color: red; width: 50%;">Question 1</td>' }
     let(:a1) { '<td style="color: red; font-size: 100px;">Answer 1</td>' }
-    let(:q2) { '<td style="color: red; width: 50%;">Question 2</td>' }
-    let(:a2) { '<td style="color: red; font-size: 100px;">Answer 2</td>' }
-    let(:heading) { '<td colspan="2" style="color: blue;">Page Heading</td>' }
+    let(:q2) { '<td style="color: red; width: 50%; padding-bottom: 20px;">Question 2</td>' }
+    let(:a2) { '<td style="color: red; font-size: 100px; padding-bottom: 20px;">Answer 2</td>' }
+    let(:heading) { '<td colspan="2" style="color: green;"><h3 style="color: blue;">Page Heading</h3></td>' }
     let(:q3) { '<td style="color: red; width: 50%;">Question 3</td>' }
     let(:a3) { '<td style="color: red; font-size: 100px;">Answer 3</td>' }
-    let(:q4) { '<td style="color: red; width: 50%;">Question 4</td>' }
-    let(:a4) { '<td style="color: red; font-size: 100px;">Answer 4</td>' }
+    let(:q4) { '<td style="color: red; width: 50%; padding-bottom: 20px;">Question 4</td>' }
+    let(:a4) { '<td style="color: red; font-size: 100px; padding-bottom: 20px;">Answer 4</td>' }
 
     it 'generates the table html' do
-      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
-      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
-      allow(helper).to receive(:heading_styles).and_return('color: blue;')
-
       expect(helper.answers_table(pages)).to eql "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
     end
-  end
-
-  describe '#answers_html' do
-    let(:q1) { '<td style="color: red; width: 50%;">Question 1</td>' }
-    let(:a1) { '<td style="color: red; font-size: 100px;">Answer 1</td>' }
-    let(:q2) { '<td style="color: red; width: 50%;">Question 2</td>' }
-    let(:a2) { '<td style="color: red; font-size: 100px;">Answer 2</td>' }
-    let(:heading) { '<td colspan="2" style="color: blue;">Page Heading</td>' }
-    let(:q3) { '<td style="color: red; width: 50%;">Question 3</td>' }
-    let(:a3) { '<td style="color: red; font-size: 100px;">Answer 3</td>' }
-    let(:q4) { '<td style="color: red; width: 50%;">Question 4</td>' }
-    let(:a4) { '<td style="color: red; font-size: 100px;">Answer 4</td>' }
 
     it 'generates the table html' do
-      allow(helper).to receive(:answer_styles).and_return('color: red; font-size: 100px;')
-      allow(helper).to receive(:question_styles).and_return('color: red; width: 50%;')
-      allow(helper).to receive(:heading_styles).and_return('color: blue;')
-
       expect(helper.answers_html(pages)).to eql "<h2>Your answers</h2><table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr></table>"
     end
   end

--- a/spec/helpers/confirmation_email_helper_spec.rb
+++ b/spec/helpers/confirmation_email_helper_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe ConfirmationEmailHelper do
     let(:q5) { '<td style="color: red; width: 50%; padding-top: 20px;">Question 5</td>' }
     let(:a5) { '<td style="color: red; font-size: 100px; padding-top: 20px;">Answer 5</td>' }
 
-    let(:table_html)  { "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr><tr>#{q5}#{a5}</tr></table>"}
+    let(:table_html)  { "<table><tr>#{q1}#{a1}</tr><tr>#{q2}#{a2}</tr><tr>#{heading}</tr><tr>#{q3}#{a3}</tr><tr>#{q4}#{a4}</tr><tr>#{q5}#{a5}</tr></table>" }
 
     it 'generates the table html' do
       expect(helper.answers_table(pages)).to eql table_html

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -87,9 +87,9 @@ RSpec.describe Platform::SubmitterPayload do
   end
   let(:answers_html) do
     ' <p>Your answers...</p>'
-  end  
+  end
   let(:env_confirmation_email_body) do
-    "Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl"
+    'Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl'
   end
   let(:confirmation_email_body) do
     "Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl#{answers_html}"

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -85,8 +85,14 @@ RSpec.describe Platform::SubmitterPayload do
   let(:confirmation_email_subject) do
     'Delicious dinosaurs'
   end
+  let(:answers_html) do
+    ' <p>Your answers...</p>'
+  end  
+  let(:env_confirmation_email_body) do
+    "Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl"
+  end
   let(:confirmation_email_body) do
-    'Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl'
+    "Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl#{answers_html}"
   end
 
   let(:pages_payload) do
@@ -218,9 +224,11 @@ RSpec.describe Platform::SubmitterPayload do
     allow(ENV).to receive(:[]).with('SERVICE_EMAIL_SUBJECT').and_return(email_subject)
     allow(ENV).to receive(:[]).with('SERVICE_EMAIL_BODY').and_return(email_body)
     allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_SUBJECT').and_return(confirmation_email_subject)
-    allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_BODY').and_return(confirmation_email_body)
+    allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_BODY').and_return(env_confirmation_email_body)
     allow(ENV).to receive(:[]).with('SERVICE_EMAIL_PDF_HEADING').and_return(pdf_heading)
     allow(ENV).to receive(:[]).with('SERVICE_EMAIL_PDF_SUBHEADING').and_return(pdf_subheading)
+
+    allow(subject).to receive(:answers_html).and_return(answers_html)
   end
 
   describe '#to_h' do
@@ -709,11 +717,11 @@ RSpec.describe Platform::SubmitterPayload do
   context 'payment links' do
     let(:payment_link) { 'http://www.mustafa.com/vader-tax?reference=' }
     let(:dummy_reference) { '1234-ABC-567' }
-    let(:confirmation_email_body) do
+    let(:env_confirmation_email_body) do
       'some email body {{payment_link}}'
     end
     let(:expected_confirmation_email_body) do
-      "some email body #{payment_link}#{dummy_reference}"
+      "some email body #{payment_link}#{dummy_reference}#{answers_html}"
     end
     let(:expected_actions) do
       [


### PR DESCRIPTION
This PR adds in a table of the user answers into the confirmation email body in the submitter payload.

I've implemented this using a helper within the ViewContext, as there are no views currently in the runner and didn't really want to add one just for this.

I'm not entirely a fan of the fact that all the helper methods are included directly into the `SubmitterPayload` class.  The only way around that would be to use a class rather than a helper, and I wasn't quite sure what to call it or where to locate it that made sense.  Open to suggestions if needed...

There's a full set of tests for the helper, as that was the best way to develop it, as its pretty hard to debug the output!