### PR TITLE
Prevent back from confirmation page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'metadata_presenter',
     github: 'ministryofjustice/fb-metadata-presenter',
     branch: 'add-submission-complete-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.0.1'
+# gem 'metadata_presenter', '3.0'
 
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 gem 'fb-jwt-auth', '0.10.0'
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'rails-7-upgrade'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'add-submission-complete-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.0'
+# gem 'metadata_presenter', '3.0.1'
 
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 gem 'fb-jwt-auth', '0.10.0'
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'add-submission-complete-page'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'add-submission-complete-page'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.0'
+gem 'metadata_presenter', '3.0.1'
 
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: bcc3cf73cd1ffff466a37ef8492893d781223a31
+  branch: add-submission-complete-page
+  specs:
+    metadata_presenter (3.0.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -175,14 +189,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.0)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -384,7 +390,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.0)
+  metadata_presenter!
   prometheus-client (~> 2.1.0)
   puma (~> 6.1)
   rails (= 7.0.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: bcc3cf73cd1ffff466a37ef8492893d781223a31
-  branch: add-submission-complete-page
-  specs:
-    metadata_presenter (3.0.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.3.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -189,6 +175,14 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.0.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.3.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.2)
@@ -390,7 +384,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.0.1)
   prometheus-client (~> 2.1.0)
   puma (~> 6.1)
   rails (= 7.0.4.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   skip_before_action VerifySession, :require_basic_auth, only: :get_saved_progress
 
-  add_flash_types :confirmation, :expired_session
+  add_flash_types :confirmation, :expired_session, :submission_completed
   rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_expired_page
 
   SESSION_DURATION = 30.minutes

--- a/app/filters/verify_session.rb
+++ b/app/filters/verify_session.rb
@@ -1,12 +1,22 @@
 class VerifySession
   def self.before(controller)
+    # if the user has just submitted their form we reset the session
+    # if they try to visit any page other than the homepage, redirect them to submission complete page
+    if controller.flash[:submission_completed].present?
+      controller.reset_session
+      controller.redirect_to '/session/complete' unless controller.request.path == controller.root_path
+    end
+
+    # if we are on a page that requires a session and it has been marked as expired
     if !controller.allowed_page? && controller.flash[:expired_session].present?
       controller.reset_session
       controller.redirect_to '/session/expired'
     end
 
+    # We need the session on the confirmtion page, but want to get rid of it after
     if !controller.allowed_page? && controller.flash[:confirmation].present?
-      controller.flash[:expired_session] = 'Session has expired'
+      # controller.flash[:expired_session] = 'Session has expired'
+      controller.flash[:submission_completed] = 'Submission completed'
     end
 
     if !controller.allowed_page? && controller.session[:session_id].blank?

--- a/spec/requests/cache_headers_spec.rb
+++ b/spec/requests/cache_headers_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe 'cache control header', type: :request do
+  before do
+    allow(VerifySession).to receive(:before).and_return false
+  end
+
+  it 'sets the no-store cache header' do
+    get '/name'
+    expect(response.headers['Cache-Control']).to eq 'no-store'
+  end
+end


### PR DESCRIPTION
## Issue
Pressing back after reaching the confirmation page would still show the 'check your answers' page with the users data even after the sesison had been deleted.

## Cause
This was caused by the browser loading the page from the cache, so it wasn't hitting the server to discover the session had ended.

## Fix Caching Headers
We currently `Cache-Control` header to `private, max-age=0, must-revalidate` which means it can't be cached in public caches (CDN), and the browser must always revalidate which should work, except that rails/rack by default sets an etag, which given that the content won't have changed means that rails will always say that the browser can use its cached version.

Instead we set the `Cache-Control` header to `no-store` which means it casn never be stored in. the browser cache. 

## Privide a nice message
With the caching header in place, if the user attempted to navigate back from the confirmation page they would be shown the 'Session expired' page.

This is not particularly explanatory for the user.  So instead we redirect to show a specific 'Form already submitted' page.

## Bonus bug fix!
The changes made to `VerifySession` also fix the bug where going to the start page after the confirmation page, then starting the foirm again would result in a delayed session reset.  This was because the confirmation page needs the session, so the session is actually reset on the next request.  However the start page is an `allowed_page` so the session didn't get reset until the request after.

Now we check for the existence of a `:submission_completed` flash message regardless of page, so the session is always reset on the request after the confirmation.