### PR TITLE
Update all references to service slug

### DIFF
--- a/app/services/platform/save_and_return.rb
+++ b/app/services/platform/save_and_return.rb
@@ -23,7 +23,7 @@ module Platform
     def adapter
       Platform::SubmitterAdapter.new(
         session:,
-        service_slug: service.service_slug,
+        service_slug: ENV['SERVICE_SLUG'],
         payload: save_and_return_payload
       )
     end

--- a/app/services/platform/save_and_return_payload.rb
+++ b/app/services/platform/save_and_return_payload.rb
@@ -29,7 +29,7 @@ module Platform
     def service_info
       {
         id: service.service_id,
-        slug: service.service_slug,
+        slug: ENV['SERVICE_SLUG'],
         name: service.service_name
       }
     end
@@ -102,19 +102,23 @@ module Platform
     end
 
     def editor_live_production_url
-      "https://#{service.service_slug}.form.service.justice.gov.uk/return/#{record_uuid}".freeze
+      "https://#{service_slug}.form.service.justice.gov.uk/return/#{record_uuid}".freeze
     end
 
     def editor_live_dev_url
-      "https://#{service.service_slug}.dev.form.service.justice.gov.uk/return/#{record_uuid}".freeze
+      "https://#{service_slug}.dev.form.service.justice.gov.uk/return/#{record_uuid}".freeze
     end
 
     def editor_test_production_url
-      "https://#{service.service_slug}.test.form.service.justice.gov.uk/return/#{record_uuid}".freeze
+      "https://#{service_slug}.test.form.service.justice.gov.uk/return/#{record_uuid}".freeze
     end
 
     def editor_test_dev_url
-      "https://#{service.service_slug}.dev.test.form.service.justice.gov.uk/return/#{record_uuid}".freeze
+      "https://#{service_slug}.dev.test.form.service.justice.gov.uk/return/#{record_uuid}".freeze
+    end
+
+    def service_slug
+      ENV['SERVICE_SLUG']
     end
   end
 end

--- a/app/services/platform/submission.rb
+++ b/app/services/platform/submission.rb
@@ -27,7 +27,7 @@ module Platform
     def adapter
       Platform::SubmitterAdapter.new(
         session:,
-        service_slug: service.service_slug,
+        service_slug: ENV['SERVICE_SLUG'],
         payload: submitter_payload
       )
     end

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -27,7 +27,7 @@ module Platform
     def service_info
       {
         id: service.service_id,
-        slug: service.service_slug,
+        slug: ENV['SERVICE_SLUG'],
         name: service.service_name
       }
     end

--- a/spec/services/platform/save_and_return_payload_spec.rb
+++ b/spec/services/platform/save_and_return_payload_spec.rb
@@ -55,19 +55,23 @@ RSpec.describe Platform::SaveAndReturnPayload do
     ]
   end
   let(:expected_email_body) { 'Magic link: https://version-fixture.dev.test.form.service.justice.gov.uk/return/some-id' }
+  let(:service_slug) do
+    'version-fixture'
+  end
 
   before do
     allow(ENV).to receive(:[])
     allow(ENV).to receive(:[]).with('SAVE_AND_RETURN_EMAIL').and_return(email_body)
     allow(ENV).to receive(:[]).with('PLATFORM_ENV').and_return('test')
     allow(ENV).to receive(:[]).with('DEPLOYMENT_ENV').and_return('dev')
+    allow(ENV).to receive(:[]).with('SERVICE_SLUG').and_return(service_slug)
   end
 
   describe '#to_h' do
     let(:service_payload) do
       {
         id: service.service_id,
-        slug: service.service_slug,
+        slug: ENV['SERVICE_SLUG'],
         name: service.service_name
       }
     end

--- a/spec/services/platform/submission_spec.rb
+++ b/spec/services/platform/submission_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe Platform::Submission do
   end
   let(:user_data) { {} }
   let(:session) { {} }
+  let(:service_slug) { 'version-fixture' }
 
   describe '#save' do
     before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('SERVICE_SLUG').and_return(service_slug)
       allow(submission).to receive(:invalid?).and_return(invalid)
     end
 
@@ -24,7 +27,7 @@ RSpec.describe Platform::Submission do
 
       it 'sends the submission' do
         expect(Platform::SubmitterAdapter).to receive(:new)
-          .with(session:, payload:, service_slug: service.service_slug)
+          .with(session:, payload:, service_slug: ENV['SERVICE_SLUG'])
           .and_return(adapter)
         expect(adapter).to receive(:save)
         submission.save
@@ -65,6 +68,7 @@ RSpec.describe Platform::Submission do
 
     before do
       allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('SERVICE_SLUG').and_return(service_slug)
       allow(ENV).to receive(:[]).with('SUBMITTER_URL').and_return(submitter_url)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_OUTPUT')
         .and_return(service_email_output)

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -223,8 +223,12 @@ RSpec.describe Platform::SubmitterPayload do
     let(:confirmation_email_body) do
       "Triceramisu, Falafel-raptor, Diplodonuts, Berry-dactyl#{answers_html}"
     end
+    let(:service_slug) do
+      'version-fixture'
+    end
 
     before do
+      allow(ENV).to receive(:[]).with('SERVICE_SLUG').and_return(service_slug)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_FROM').and_return(email_from)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_SUBJECT').and_return(email_subject)
       allow(ENV).to receive(:[]).with('SERVICE_EMAIL_BODY').and_return(email_body)
@@ -239,7 +243,7 @@ RSpec.describe Platform::SubmitterPayload do
       let(:service_payload) do
         {
           id: service.service_id,
-          slug: service.service_slug,
+          slug: ENV['SERVICE_SLUG'],
           name: service.service_name
         }
       end


### PR DESCRIPTION
Currently we have a few references to `service.service_slug`, this is not correct as we no longer use the service_name to create a service slug.

Update these to reference the 'SERVICE_SLUG' env var which is injected into the runner pods on publish.