### PR TITLE
Enable nonce for CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,8 +21,8 @@ Rails.application.configure do
   end
 #
 #   # Generate session nonces for permitted importmap and inline scripts
-  # config.content_security_policy_nonce_generator = ->(request) { request.session[:session_id] }
-  # config.content_security_policy_nonce_directives = %w(script-src)
+  config.content_security_policy_nonce_generator = ->(request) { request.session[:session_id] }
+  config.content_security_policy_nonce_directives = %w(script-src)
 #
 #   # Report violations without enforcing the policy.
     config.content_security_policy_report_only = true


### PR DESCRIPTION
We have been seeing many CSP violations on windows os relating to google tag manager.

As per the google tag manager docs, we have injected a nonce to the GTM script in the presenter.

To make this work, we need to enable nonce on the runner side.