### PR TITLE
Update to browser-tools 1.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   ruby: circleci/ruby@1.4.0
   node: circleci/node@5.1.0
   slack: circleci/slack@3.4.2
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.3
 
 jobs:
   build:
@@ -122,8 +122,8 @@ jobs:
     docker: *ruby_image
     steps:
       - checkout
-      - browser-tools/install-browser-tools:
-          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   ruby: circleci/ruby@1.4.0
   node: circleci/node@5.1.0
   slack: circleci/slack@3.4.2
-  browser-tools: circleci/browser-tools@1.2.4
+  browser-tools: circleci/browser-tools@1.4.1
 
 jobs:
   build:
@@ -122,8 +122,8 @@ jobs:
     docker: *ruby_image
     steps:
       - checkout
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools:
+          chrome-version: 114.0.5735.90 # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - run:
           name: Check browser tools install
           command: |


### PR DESCRIPTION
### Update to browser-tools 1.4.3
Our pipeline was failing due to browser tools unsuccessfully downloading the latest chromedriver.
The maintainers have released a newbrowser-tools version that successfully installs Chromedriver v115