### PR TITLE
Fix missing content styles

### DIFF
--- a/app/javascript/styles/shared/_content.scss
+++ b/app/javascript/styles/shared/_content.scss
@@ -19,3 +19,38 @@
 .fb-editable[data-fb-content-type="content"] a {
   @extend %govuk-link;
 }
+
+// Apply GOVUk link styles to all links in editable content areas
+editable-content {
+  a {
+    @extend %govuk-link;
+  }
+
+  table {
+    @include govuk-font($size: 19);
+    @include govuk-text-colour;
+    width: 100%;
+    @include govuk-responsive-margin(6, "bottom");
+
+    border-spacing: 0;
+    border-collapse: collapse;
+  }
+
+  thead td,
+  thead th {
+    @include govuk-typography-weight-bold;
+  }
+
+  td, th {
+    padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
+    border-bottom: 1px solid $govuk-border-colour;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  td:last-child,
+  th:last-child {
+    padding-right: 0;
+  }
+}
+


### PR DESCRIPTION
Editable content styles were missing from the runner, meaning links and tables in content areas weren't being rendered correctly:

## Before:
<img width="862" alt="image" src="https://github.com/ministryofjustice/fb-runner/assets/595564/4b04da68-67af-46ea-ace4-a3bcea2c7912">

## After
<img width="851" alt="image" src="https://github.com/ministryofjustice/fb-runner/assets/595564/a4be386c-ebdd-47ec-94ea-1e08d9f7fe25">
