### PR TITLE
Fix skip link navigating back

### DIFF
--- a/app/javascript/src/runner/timeout-warning.js
+++ b/app/javascript/src/runner/timeout-warning.js
@@ -277,8 +277,6 @@ TimeoutWarning.prototype.disableBackButtonWhenOpen = function () {
   window.addEventListener('popstate', function () {
     if (module.isDialogOpen()) {
       module.modalDialog.close()
-    } else {
-      window.history.go(-1)
     }
   })
 }

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -13,6 +13,8 @@ RSpec.feature 'Navigation' do
     and_I_add_my_email
     and_I_go_back
     then_I_should_see_my_email
+    and_I_use_the_skip_link
+    then_I_should_see_my_email
     and_I_go_back
     then_I_should_see_my_full_name
   end
@@ -137,6 +139,10 @@ RSpec.feature 'Navigation' do
 
   def and_I_remove_the_file
     click_link 'Remove file'
+  end
+
+  def and_I_use_the_skip_link
+    click_link 'Skip to main content', visible: false
   end
 
   def and_I_change_the_answer_for_dog_picture


### PR DESCRIPTION
Remove unnecessary back navigation in timeout warning modal `popstate` event.

Add test tpo ensure this behaviour remains correct.