### PR TITLE
Timeout warning screenreader fix

### DIFF
--- a/app/javascript/src/runner/timeout-warning.js
+++ b/app/javascript/src/runner/timeout-warning.js
@@ -222,8 +222,10 @@ TimeoutWarning.prototype.startUiCountdown = function () {
       }
 
       if (!timerRunOnce) {
-        $accessibleCountdown.innerText = atText + $module.timerExtraText
-        timerRunOnce = true
+        setTimeout(() => { // Ensures text is read out just after modal opens
+          $accessibleCountdown.innerText = atText + ' ' + $module.timerExtraText
+          timerRunOnce = true
+        }, 1000)
       } else if (secondsLeft % 15 === 0) {
         // Update screen reader friendly content every 15 secs
         $accessibleCountdown.innerText = atText


### PR DESCRIPTION
Accessibility audit raised the issue that the contents of the timeout modal were not fully read out in all screenreader/browser combinations.

This fix introduces a 1s delay before the contents of the modal are inserted into the element with the `status` role.  This small delay seems to ensure that all screenreaders pick up the addition and announce the content after announcing the opening of the modal.

![image](https://github.com/ministryofjustice/fb-runner/assets/595564/32dc3f00-cfb6-4d74-8301-3f0b162f524d)
