### PR TITLE
Inform form filler of the confirmation email

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,35 +236,36 @@ workflows:
             branches:
               only:
                 - main
+                - confirmation-email-data-risk
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      - deploy_to_test_production:
-          context: *moj-forms-context
-          requires:
-            - build_and_push_image_test
-      - acceptance_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - deploy_to_test_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - build_and_push_image_test
+      # - acceptance_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_test_dev
+      #       - deploy_to_test_production
+      # - build_and_push_image_live:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      # - deploy_to_live_dev:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - deploy_to_live_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      # - smoke_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,36 +236,35 @@ workflows:
             branches:
               only:
                 - main
-                - confirmation-email-data-risk
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      # - deploy_to_test_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - build_and_push_image_test
-      # - acceptance_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_test_dev
-      #       - deploy_to_test_production
-      # - build_and_push_image_live:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      # - deploy_to_live_dev:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      # - deploy_to_live_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      # - smoke_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+      - deploy_to_test_production:
+          context: *moj-forms-context
+          requires:
+            - build_and_push_image_test
+      - acceptance_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_test_dev
+            - deploy_to_test_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,9 @@ gem 'jwt'
 gem 'fb-jwt-auth', '0.10.0'
 # gem 'metadata_presenter',
 #     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 's-and-r-date-fix'
+#     branch: 'confirmation-email-data-risk'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.7'
+gem 'metadata_presenter', '3.2.8'
 
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: c82fa3ef6bbabe49c9a46e07a3b5782eaa0db4ac
+  branch: confirmation-email-data-risk
+  specs:
+    metadata_presenter (3.2.3)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -216,15 +231,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.7)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -638,7 +644,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.2.7)
+  metadata_presenter!
   prometheus-client (~> 2.1.0)
   puma (~> 6.1)
   rails (= 7.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 9ad979bd5fb0a8817f2711c3fd51be3e279f7159
-  branch: confirmation-email-data-risk
-  specs:
-    metadata_presenter (3.2.6)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -193,7 +178,7 @@ GEM
     govuk_personalisation (0.14.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.13.2)
+    govuk_publishing_components (35.14.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -231,6 +216,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.2.8)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -644,7 +638,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.2.8)
   prometheus-client (~> 2.1.0)
   puma (~> 6.1)
   rails (= 7.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: c82fa3ef6bbabe49c9a46e07a3b5782eaa0db4ac
+  revision: 75a436870db7c03e086c192826fe1808169c4196
   branch: confirmation-email-data-risk
   specs:
-    metadata_presenter (3.2.3)
+    metadata_presenter (3.2.6)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 75a436870db7c03e086c192826fe1808169c4196
+  revision: c7c53016367f75ee15064d4af469dd348d945cbc
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.6)
@@ -193,7 +193,7 @@ GEM
     govuk_personalisation (0.14.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.14.0)
+    govuk_publishing_components (35.13.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: c7c53016367f75ee15064d4af469dd348d945cbc
+  revision: 7075370b4377a0ee4c818a2efc027eed7f578ba4
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 7075370b4377a0ee4c818a2efc027eed7f578ba4
+  revision: 9ad979bd5fb0a8817f2711c3fd51be3e279f7159
   branch: confirmation-email-data-risk
   specs:
     metadata_presenter (3.2.6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -221,4 +221,9 @@ class ApplicationController < ActionController::Base
     load_user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] if confirmation_email_enabled?
   end
   helper_method :confirmation_email
+
+  def is_confirmation_email_question?
+    ENV['CONFIRMATION_EMAIL_COMPONENT_ID'] == @page.metadata.components[0]['_id'] if confirmation_email_enabled?
+  end
+  helper_method :is_confirmation_email_question?
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -210,4 +210,9 @@ class ApplicationController < ActionController::Base
     false
   end
   helper_method :editor_preview?
+
+  def confirmation_email_enabled?
+    ENV['CONFIRMATION_EMAIL_COMPONENT_ID'].present?
+  end
+  helper_method :confirmation_email_enabled?
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -217,7 +217,7 @@ class ApplicationController < ActionController::Base
   helper_method :confirmation_email_enabled?
 
   def confirmation_email
-    load_user_data['user_data'][ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] if confirmation_email_enabled?
+    load_user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] if confirmation_email_enabled?
   end
   helper_method :confirmation_email
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -217,7 +217,7 @@ class ApplicationController < ActionController::Base
   helper_method :confirmation_email_enabled?
 
   def confirmation_email
-    user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] if confirmation_email_enabled?
+    load_user_data['user_data'][ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] if confirmation_email_enabled?
   end
   helper_method :confirmation_email
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,6 +89,8 @@ class ApplicationController < ActionController::Base
   end
 
   def create_submission
+    remove_user_data(ENV['CONFIRMATION_EMAIL_COMPONENT_ID']) if params['confirmation_email_optin'].blank?
+
     user_data = update_session_with_reference_number_if_enabled(session)
     # rubocop: disable Rails/SaveBang
     Platform::Submission.new(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -215,4 +215,9 @@ class ApplicationController < ActionController::Base
     ENV['CONFIRMATION_EMAIL_COMPONENT_ID'].present?
   end
   helper_method :confirmation_email_enabled?
+
+  def confirmation_email
+    user_data[ENV['CONFIRMATION_EMAIL_COMPONENT_ID']] if confirmation_email_enabled?
+  end
+  helper_method :confirmation_email
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -89,9 +89,8 @@ class ApplicationController < ActionController::Base
   end
 
   def create_submission
-    remove_user_data(ENV['CONFIRMATION_EMAIL_COMPONENT_ID']) if params['confirmation_email_optin'].blank?
-
     user_data = update_session_with_reference_number_if_enabled(session)
+
     # rubocop: disable Rails/SaveBang
     Platform::Submission.new(
       service:,

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -174,40 +174,4 @@ RSpec.describe ApplicationController do
       end
     end
   end
-
-  describe '#create_submission' do
-    let(:session) { { 'user_data' => { 'email_email_1' => 'e@mail.com' } } }
-
-    before do
-      allow(ENV).to receive(:[])
-      allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_COMPONENT_ID').and_return('email_email_1')
-      allow(controller).to receive(:load_user_data).and_return(session)
-    end
-
-    context 'when confirmation email optin is enabled' do
-      before do
-        allow_any_instance_of(ActionController::Parameters).to receive(:[]).with('confirmation_email_optin').and_return('true')
-      end
-
-      it 'does not alter the email component ID from the user data' do
-        initial_user_data = controller.load_user_data
-        controller.update_if_user_optout_confirmation_email
-        final_data = controller.reload_user_data
-        expect(initial_user_data).to eq(final_data)
-      end
-    end
-
-    context 'when confirmation email optin is disabled' do
-      before do
-        allow_any_instance_of(ActionController::Parameters).to receive(:[]).with('confirmation_email_optin').and_return(nil)
-      end
-
-      it 'removes the email component ID from the user data' do
-        initial_user_data = controller.load_user_data
-        controller.update_if_user_optout_confirmation_email
-        final_data = controller.reload_user_data
-        expect(initial_user_data).to_not eq(final_data)
-      end
-    end
-  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe ApplicationController do
 
       before do
         allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_COMPONENT_ID').and_return('email_email_1')
-        allow(controller).to receive(:load_user_data).and_return(session)
+        allow(controller).to receive(:load_user_data).and_return(session['user_data'])
       end
 
       it 'confirmation_email_enabled? will return true' do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -137,4 +137,41 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#confirmation_email' do
+    before do
+      allow(ENV).to receive(:[])
+    end
+
+    context 'when confirmation email is not enabled' do
+      before do
+        allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_COMPONENT_ID').and_return(nil)
+      end
+
+      it 'confirmation_email_enabled? will return false' do
+        expect(controller.confirmation_email_enabled?).to be_falsey
+      end
+
+      it 'confirmation email is nil' do
+        expect(controller.confirmation_email).to be_nil
+      end
+    end
+
+    context 'when confirmation email is enabled' do
+      let(:session) { { 'user_data' => { 'email_email_1' => 'e@mail.com' } } }
+
+      before do
+        allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_COMPONENT_ID').and_return('email_email_1')
+        allow(controller).to receive(:load_user_data).and_return(session)
+      end
+
+      it 'confirmation_email_enabled? will return true' do
+        expect(controller.confirmation_email_enabled?).to be_truthy
+      end
+
+      it 'confirmation email is being retrieved from the user data' do
+        expect(controller.confirmation_email).to eq('e@mail.com')
+      end
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -174,4 +174,40 @@ RSpec.describe ApplicationController do
       end
     end
   end
+
+  describe '#create_submission' do
+    let(:session) { { 'user_data' => { 'email_email_1' => 'e@mail.com' } } }
+
+    before do
+      allow(ENV).to receive(:[])
+      allow(ENV).to receive(:[]).with('CONFIRMATION_EMAIL_COMPONENT_ID').and_return('email_email_1')
+      allow(controller).to receive(:load_user_data).and_return(session)
+    end
+
+    context 'when confirmation email optin is enabled' do
+      before do
+        allow_any_instance_of(ActionController::Parameters).to receive(:[]).with('confirmation_email_optin').and_return('true')
+      end
+
+      it 'does not alter the email component ID from the user data' do
+        initial_user_data = controller.load_user_data
+        controller.update_if_user_optout_confirmation_email
+        final_data = controller.reload_user_data
+        expect(initial_user_data).to eq(final_data)
+      end
+    end
+
+    context 'when confirmation email optin is disabled' do
+      before do
+        allow_any_instance_of(ActionController::Parameters).to receive(:[]).with('confirmation_email_optin').and_return(nil)
+      end
+
+      it 'removes the email component ID from the user data' do
+        initial_user_data = controller.load_user_data
+        controller.update_if_user_optout_confirmation_email
+        final_data = controller.reload_user_data
+        expect(initial_user_data).to_not eq(final_data)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/SzV8RNaW/3524-inform-form-filler-of-the-confirmation-email)

This PR simply pulls the last metadata presenter for informing the user of the confirmation email. It also implement how to pull the confirmation email from the user data pages answers.