### PR TITLE
Confirmation Email Disclaimer for Multiple Components Page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,36 +236,35 @@ workflows:
             branches:
               only:
                 - main
-                - disclaimer-multiple-email
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-#      - deploy_to_test_production:
-#          context: *moj-forms-context
-#          requires:
-#            - build_and_push_image_test
-#      - acceptance_tests:
-#          context: *moj-forms-context
-#          requires:
-#            - deploy_to_test_dev
-#            - deploy_to_test_production
-#      - build_and_push_image_live:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#      - deploy_to_live_dev:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#      - deploy_to_live_production:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#      - smoke_tests:
-#          context: *moj-forms-context
-#          requires:
-#            - deploy_to_live_dev
-#            - deploy_to_live_production
+      - deploy_to_test_production:
+          context: *moj-forms-context
+          requires:
+            - build_and_push_image_test
+      - acceptance_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_test_dev
+            - deploy_to_test_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,35 +236,36 @@ workflows:
             branches:
               only:
                 - main
+                - disclaimer-multiple-email
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      - deploy_to_test_production:
-          context: *moj-forms-context
-          requires:
-            - build_and_push_image_test
-      - acceptance_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+#      - deploy_to_test_production:
+#          context: *moj-forms-context
+#          requires:
+#            - build_and_push_image_test
+#      - acceptance_tests:
+#          context: *moj-forms-context
+#          requires:
+#            - deploy_to_test_dev
+#            - deploy_to_test_production
+#      - build_and_push_image_live:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#      - deploy_to_live_dev:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#      - deploy_to_live_production:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#      - smoke_tests:
+#          context: *moj-forms-context
+#          requires:
+#            - deploy_to_live_dev
+#            - deploy_to_live_production

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 gem 'fb-jwt-auth', '0.10.0'
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'confirmation-email-data-risk'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'disclaimer-multiple-email'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.2.8'
+# gem 'metadata_presenter', '3.2.8'
 
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.1'

--- a/Gemfile
+++ b/Gemfile
@@ -11,11 +11,11 @@ gem 'jwt'
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
 gem 'fb-jwt-auth', '0.10.0'
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'disclaimer-multiple-email'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'disclaimer-multiple-email'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.2.8'
+gem 'metadata_presenter', '3.2.9'
 
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 0ea0a19ff67cf1a0ae6a6855b8cce0a73ada3da1
+  branch: disclaimer-multiple-email
+  specs:
+    metadata_presenter (3.2.8)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -145,7 +160,7 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-protobuf (3.24.0)
+    google-protobuf (3.24.1)
     googleapis-common-protos-types (1.8.0)
       google-protobuf (~> 3.18)
     govspeak (7.1.1)
@@ -216,15 +231,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.2.8)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -638,7 +644,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.2.8)
+  metadata_presenter!
   prometheus-client (~> 2.1.0)
   puma (~> 6.1)
   rails (= 7.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 0ea0a19ff67cf1a0ae6a6855b8cce0a73ada3da1
-  branch: disclaimer-multiple-email
-  specs:
-    metadata_presenter (3.2.8)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (= 2.8.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -231,6 +216,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.2.9)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (= 2.8.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.4)
@@ -644,7 +638,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.2.9)
   prometheus-client (~> 2.1.0)
   puma (~> 6.1)
   rails (= 7.0.5)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -222,8 +222,8 @@ class ApplicationController < ActionController::Base
   end
   helper_method :confirmation_email
 
-  def is_confirmation_email_question?
-    ENV['CONFIRMATION_EMAIL_COMPONENT_ID'] == @page.metadata.components[0]['_id'] if confirmation_email_enabled?
+  def is_confirmation_email_question?(component_id)
+    ENV['CONFIRMATION_EMAIL_COMPONENT_ID'] == component_id if confirmation_email_enabled?
   end
   helper_method :is_confirmation_email_question?
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/ddAPdi9h/3667-confirmation-email-disclaimer-for-multiple-component-page)

We're using the last version of the metadata presenter and specify exactly what component id to display properly in a multiple component page.

On the multiple question page:
<img width="883" alt="Screenshot 2023-08-24 at 14 31 39" src="https://github.com/ministryofjustice/fb-runner/assets/26165112/8297edaa-09ab-42d8-a4b2-ada27d048b41">

On the CYA page:
<img width="880" alt="Screenshot 2023-08-24 at 14 32 36" src="https://github.com/ministryofjustice/fb-runner/assets/26165112/529c5182-5fe4-43e4-aa35-387ff78d78c4">
