### PR TITLE
Add additional context to date answer exceptions

### DIFF
--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -95,7 +95,7 @@ module Platform
         send(component_type, answer)
       rescue StandardError
         Sentry.configure_scope do |scope|
-          scope.set_context('answer_for', { component_type:, component_id:, answer: })
+          scope.set_context('answer_for', { component_type:, component_id:, answer: answer.inspect })
         end
 
         raise # re-raise the exception

--- a/app/services/platform/submitter_payload.rb
+++ b/app/services/platform/submitter_payload.rb
@@ -81,12 +81,24 @@ module Platform
 
     def answer_for(page, component)
       page_answers = MetadataPresenter::PageAnswers.new(page, user_data)
-      answer = page_answers.send(component.id)
 
-      if self.class.private_method_defined?(component.type.to_sym)
-        send(component.type.to_sym, answer)
-      else
-        answer&.strip
+      component_type = component.type
+      component_id = component.id
+
+      answer = page_answers.send(component_id)
+
+      return answer&.strip unless self.class.private_method_defined?(component_type)
+
+      begin
+        # For component types like `date`, `checkboxes`, etc.
+        # we call private methods having the same name as the type
+        send(component_type, answer)
+      rescue StandardError
+        Sentry.configure_scope do |scope|
+          scope.set_context('answer_for', { component_type:, component_id:, answer: })
+        end
+
+        raise # re-raise the exception
       end
     end
 

--- a/spec/services/platform/submitter_payload_spec.rb
+++ b/spec/services/platform/submitter_payload_spec.rb
@@ -584,7 +584,7 @@ RSpec.describe Platform::SubmitterPayload do
             {
               component_type: 'date',
               component_id: 'holiday_date_1',
-              answer: instance_of(MetadataPresenter::DateField)
+              answer: /@day="29", @month="02", @year="2023"/
             }
           )
 


### PR DESCRIPTION
On the back of this sentry exception:
https://ministryofjustice.sentry.io/issues/4612935516

Added some additional context that will be attached to the sentry exception so we can investigate difficult to diagnose exceptions occurring with the parsing of some answers, in this case date answers.

The code can handle exceptions in other component types, those defined as methods, so: date, checkboxes, upload, multiupload and autocomplete. But realistically only date and perhaps autocomplete may raise exceptions, as the other components are trivial.

More info:
https://docs.sentry.io/platforms/ruby/enriching-events/context/