### PR TITLE
Customise timeouts and propagate request id

### DIFF
--- a/app/services/platform/encrypted_user_id_and_token.rb
+++ b/app/services/platform/encrypted_user_id_and_token.rb
@@ -5,7 +5,7 @@ module Platform
 
       DataEncryption.new(
         key: service_secret
-      ).encrypt("#{user_id}#{session[:user_token]}")
+      ).encrypt("#{session[:user_id]}#{session[:user_token]}")
     end
   end
 end

--- a/app/services/platform/submitter_adapter.rb
+++ b/app/services/platform/submitter_adapter.rb
@@ -5,7 +5,6 @@ module Platform
     attr_reader :payload, :session, :root_url, :service_slug, :service_secret
 
     SUBSCRIPTION = 'submitter.request'.freeze
-    TIMEOUT = 30
     V2_URL = '/v2/submissions'.freeze
 
     def initialize(payload:,
@@ -45,10 +44,6 @@ module Platform
 
     def subscription
       SUBSCRIPTION
-    end
-
-    def timeout
-      TIMEOUT
     end
   end
 end

--- a/app/services/platform/user_datastore_adapter.rb
+++ b/app/services/platform/user_datastore_adapter.rb
@@ -1,7 +1,6 @@
 module Platform
   class UserDatastoreAdapter
     include Platform::Connection
-    TIMEOUT = 30
     SUBSCRIPTION = 'datastore.request'.freeze
 
     attr_reader :session, :root_url, :service_slug
@@ -138,10 +137,6 @@ module Platform
 
     def subscription
       SUBSCRIPTION
-    end
-
-    def timeout
-      TIMEOUT
     end
   end
 end

--- a/app/services/platform/user_filestore_adapter.rb
+++ b/app/services/platform/user_filestore_adapter.rb
@@ -46,8 +46,8 @@ module Platform
       SUBSCRIPTION
     end
 
-    def timeout
-      30
+    def read_timeout
+      45
     end
 
     def payload

--- a/app/services/platform/user_filestore_payload.rb
+++ b/app/services/platform/user_filestore_payload.rb
@@ -1,6 +1,5 @@
 module Platform
   class UserFilestorePayload
-    include Platform::Connection
     include Platform::EncryptedUserIdAndToken
 
     attr_reader :session, :file_details, :service_secret, :allowed_file_types


### PR DESCRIPTION
Faraday can be customised with different timeouts for open and read operations. Open operation can have a small timeout, set to 10 seconds but if we observe any issues we can tweak this.

Read timeout can be configured per adapter. I've left all adapters to 30 secs (as before) except the filestore adapter that I've increased to 45 secs in a attempt to reduce timeouts errors we get from time to time. However this may still be not enough so we can observe and tweak if necessary.

Finally, probably the most important thing, we are now propagating the request Id, so each service (filestore, datastore, etc.) would get it and we can correlate requests from the runner to each of these services, which is very useful when looking at the logs.