### PR TITLE
Add debug to help diagnose unfiltered params issue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,6 +50,17 @@ class ApplicationController < ActionController::Base
 
   def user_data_params
     UserDataParams.new(@page_answers).answers
+  rescue ActionController::UnfilteredParameters
+    # rubocop:disable Style/RescueModifier
+    Sentry.set_context(
+      'debug', {
+        answers_keys: (@page_answers.answers.keys rescue nil),
+        uploaded_files: (@page_answers.uploaded_files.size rescue nil)
+      }
+    )
+    # rubocop:enable Style/RescueModifier
+
+    raise # re-raise
   end
 
   def load_user_data


### PR DESCRIPTION
We are having some random exceptions:

```
ActionController::UnfilteredParameters
unable to convert unpermitted parameters to hash
```

I can't find a clear source of the issue, other than the obvious stated by the exception that the params have not been filtered, however the code performs filtering.

Adding a bit of debug context to the sentry alert to try to diagnose the issue.