### PR TITLE
Workaround for random unfiltered params error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,17 +50,6 @@ class ApplicationController < ActionController::Base
 
   def user_data_params
     UserDataParams.new(@page_answers).answers
-  rescue ActionController::UnfilteredParameters
-    # rubocop:disable Style/RescueModifier
-    Sentry.set_context(
-      'debug', {
-        answers_keys: (@page_answers.answers.keys rescue nil),
-        uploaded_files: (@page_answers.uploaded_files.size rescue nil)
-      }
-    )
-    # rubocop:enable Style/RescueModifier
-
-    raise # re-raise
   end
 
   def load_user_data

--- a/app/models/user_data_params.rb
+++ b/app/models/user_data_params.rb
@@ -1,28 +1,38 @@
 class UserDataParams
   def initialize(page_answers)
     @page_answers = page_answers
-    @answer_params = @page_answers.answers.to_h
+    @answer_params = params_hash
   end
 
   def answers
     set_uploaded_file_details
     set_optional_checkboxes
 
-    @answer_params
+    answer_params
   end
 
   private
 
+  attr_reader :page_answers, :answer_params
+
+  def params_hash
+    answers = page_answers.answers
+
+    # `answers` can also be a `MetadataPresenter::MultiUploadAnswer`, thus this check
+    answers.permit! if answers.is_a?(ActionController::Parameters)
+    answers.to_h
+  end
+
   def set_uploaded_file_details
-    if @page_answers.uploaded_files.present?
-      @page_answers.uploaded_files.map do |uploaded_file|
+    if page_answers.uploaded_files.present?
+      page_answers.uploaded_files.map do |uploaded_file|
         if uploaded_file.component.type == 'multiupload'
           # merge the uploaded file into the last file in the component
-          @answer_params[uploaded_file.component.id][-1] =
-            @page_answers.send(uploaded_file.component.id)[uploaded_file.component.id].last.merge(uploaded_file.file)
+          answer_params[uploaded_file.component.id][-1] =
+            page_answers.send(uploaded_file.component.id)[uploaded_file.component.id].last.merge(uploaded_file.file)
         else
-          @answer_params[uploaded_file.component.id] =
-            @page_answers.send(uploaded_file.component.id).merge(uploaded_file.file)
+          answer_params[uploaded_file.component.id] =
+            page_answers.send(uploaded_file.component.id).merge(uploaded_file.file)
         end
       end
     end
@@ -30,13 +40,13 @@ class UserDataParams
 
   def set_optional_checkboxes
     checkbox_components.each do |component|
-      @answer_params[component.id] = [] if @page_answers.send(component.id).blank?
+      answer_params[component.id] = [] if page_answers.send(component.id).blank?
     end
   end
 
   def checkbox_components
     # not all pages have components
-    Array(@page_answers.page.components).select do |component|
+    Array(page_answers.page.components).select do |component|
       component.type == 'checkboxes'
     end
   end


### PR DESCRIPTION
We couldn't find the source of the problem, why for some reason a few requests a day produce unfiltered params error.

So far all I can see is we are filtering (in the metadata presenter) the params, and permitting the answers (`params[:answers].permit!`)

Why somehow in some scenarios this permitted params object become unpermitted or contains unpermitted params is still a mistery.

This workaround does not fix whatever is the underlying issue but fix the result of it by re-permitting the answer params, which in the debug introduced previously it always seems to be 1 upload param.