### PR TITLE
Another workaround for unfiltered params error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,6 @@ workflows:
             branches:
               only:
                 - main
-                - another-workaround
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ workflows:
             branches:
               only:
                 - main
+                - another-workaround
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:

--- a/app/models/user_data_params.rb
+++ b/app/models/user_data_params.rb
@@ -35,7 +35,7 @@ class UserDataParams
       rescue ActionController::UnfilteredParameters => e
         Sentry.set_context(
           'debug', {
-            file: ActiveSupport::ParameterFilter.new([:tempfile, :filename]).filter(file).inspect
+            file: ActiveSupport::ParameterFilter.new(%i[tempfile filename]).filter(file).inspect
           }
         )
         Sentry.capture_exception(e)


### PR DESCRIPTION
This is another instance of the unpermitted params edge case. It has been uncovered due to the previous PR #1314.

Added a rescue in case this happens to notify sentry and permit the params so the user should not see an error. Added some additional debug context for sentry too.