### PR TITLE
Update metadata presenter gem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,35 +4,19 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
+
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0
+
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily
-    time: "03:00"
-    timezone: Europe/London
-  open-pull-requests-limit: 10
-  reviewers:
-  - mattempty
-  - chrispymm
-  - H3ll3m4
-  - StevenLeighton21
+  # Disable version updates, but leave security updates
+  open-pull-requests-limit: 0

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'unfiltered-params'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'unfiltered-params'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.3'
+gem 'metadata_presenter', '3.3.4'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false
@@ -17,12 +17,12 @@ gem 'faraday'
 gem 'faraday_middleware'
 gem 'fb-jwt-auth', '0.10.0'
 gem 'jwt'
-gem 'prometheus-client', '~> 4.1.0'
+gem 'prometheus-client', '~> 4.2.0'
 gem 'puma', '~> 6.4'
 gem 'rails', '7.0.5'
 gem 'sass-rails', '>= 6'
-gem 'sentry-rails', '~> 5.12.0'
-gem 'sentry-ruby', '~> 5.12.0'
+gem 'sentry-rails', '~> 5.14'
+gem 'sentry-ruby', '~> 5.14'
 gem 'webpacker', '~> 5.4'
 
 group :development, :test do
@@ -33,7 +33,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'simplecov'
   gem 'simplecov-console'
-  gem 'site_prism', '4.0'
+  gem 'site_prism', '< 5.0'
   gem 'timecop'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 5b88c5473eed09289fae70616191716459a69b3c
-  branch: unfiltered-params
-  specs:
-    metadata_presenter (3.3.3)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (>= 2.1.5)
-      json-schema (~> 4.1.1)
-      kramdown (>= 2.4.0)
-      rails (>= 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -85,21 +70,21 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ansi (1.5.0)
     ast (2.4.2)
-    aws-eventstream (1.2.0)
-    aws-partitions (1.831.0)
-    aws-sdk-core (3.185.0)
-      aws-eventstream (~> 1, >= 1.0.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.860.0)
+    aws-sdk-core (3.189.0)
+      aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.5)
+      aws-sigv4 (~> 1.8)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.72.0)
-      aws-sdk-core (~> 3, >= 3.184.0)
+    aws-sdk-kms (1.74.0)
+      aws-sdk-core (~> 3, >= 3.188.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.136.0)
-      aws-sdk-core (~> 3, >= 3.181.0)
+    aws-sdk-s3 (1.141.0)
+      aws-sdk-core (~> 3, >= 3.189.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.6)
-    aws-sigv4 (1.6.0)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -193,7 +178,7 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.23.0)
+    govuk_publishing_components (36.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -231,6 +216,15 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.3.4)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (>= 2.1.5)
+      json-schema (~> 4.1.1)
+      kramdown (>= 2.4.0)
+      rails (>= 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -445,10 +439,11 @@ GEM
     opentelemetry-semantic_conventions (1.10.0)
       opentelemetry-api (~> 1.0)
     parallel (1.23.0)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
     plek (5.0.0)
-    prometheus-client (4.1.0)
+    prometheus-client (4.2.2)
     prometheus_exporter (2.0.8)
       webrick
     public_suffix (5.0.4)
@@ -497,7 +492,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (2.8.1)
+    regexp_parser (2.8.2)
     request_store (1.5.1)
       rack (>= 1.4)
     rexml (3.2.6)
@@ -511,7 +506,7 @@ GEM
     rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-rails (6.0.3)
+    rspec-rails (6.1.0)
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       railties (>= 6.1)
@@ -533,9 +528,9 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
-    rubocop-capybara (2.18.0)
+    rubocop-capybara (2.19.0)
       rubocop (~> 1.41)
-    rubocop-factory_bot (2.23.1)
+    rubocop-factory_bot (2.24.0)
       rubocop (~> 1.33)
     rubocop-govuk (4.12.0)
       rubocop (= 1.55.0)
@@ -569,10 +564,10 @@ GEM
       sprockets-rails
       tilt
     semantic_range (3.0.0)
-    sentry-rails (5.12.0)
+    sentry-rails (5.14.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.12.0)
-    sentry-ruby (5.12.0)
+      sentry-ruby (~> 5.14.0)
+    sentry-ruby (5.14.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -584,12 +579,12 @@ GEM
       terminal-table
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    site_prism (4.0)
+    site_prism (4.0.3)
       addressable (~> 2.8)
       capybara (~> 3.27)
       site_prism-all_there (~> 2.0)
     site_prism-all_there (2.0.2)
-    spring (4.1.1)
+    spring (4.1.3)
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
       spring (>= 4)
@@ -609,8 +604,8 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.4.2)
-    web-console (4.2.0)
+    unicode-display_width (2.5.0)
+    web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
@@ -647,8 +642,8 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter!
-  prometheus-client (~> 4.1.0)
+  metadata_presenter (= 3.3.4)
+  prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (= 7.0.5)
   rails-controller-testing
@@ -656,11 +651,11 @@ DEPENDENCIES
   rubocop (~> 1.55.0)
   rubocop-govuk
   sass-rails (>= 6)
-  sentry-rails (~> 5.12.0)
-  sentry-ruby (~> 5.12.0)
+  sentry-rails (~> 5.14)
+  sentry-ruby (~> 5.14)
   simplecov
   simplecov-console
-  site_prism (= 4.0)
+  site_prism (< 5.0)
   spring (~> 4.1.1)
   spring-watcher-listen (~> 2.1.0)
   timecop


### PR DESCRIPTION
Using latest metadata presenter, version 3.3.4

We've shifted the handling of unfiltered params edge case to the metadata presenter gem, so by using version 3.3.4 of the gem we are now able to remove all this code.

Update `dependabot.yml` to only raise PR for security versions, and not for version updates. Also updated several gems to latest minor versions.

Closes #1320
Closes #1310
Closes #1311
Closes #1273
Closes #1222
Closes #1298
Closes #1318
