### PR TITLE
Prevent error when page object is nil, such as when session expires

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -228,7 +228,11 @@ class ApplicationController < ActionController::Base
   helper_method :is_confirmation_email_question?
 
   def first_page?
-    @page.url == service.pages[1].url
+    if @page.present?
+      @page.url == service.pages[1].url
+    else
+      false
+    end
   end
   helper_method :first_page?
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -288,6 +288,16 @@ RSpec.describe ApplicationController do
           expect(controller.first_page?).to eq(true)
         end
       end
+
+      context 'page is nil' do
+        before do
+          controller.instance_eval { @page = nil }
+        end
+
+        it 'handles gracefully' do
+          expect(controller.first_page?).to eq(false)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This will just quietly allow this helper to stop throwing an error, in the case of an expired session this should now redirect as expected.
In any other case, this helper is only used to determine if we should show the info panel, and if page is nil then we're unable to render anything anyway