### PR TITLE
Use latest MDP version 3.3.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,6 @@ workflows:
             branches:
               only:
                 - main
-                - bugfix/content-with-validation-errors
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -283,31 +282,31 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      # - build_and_push_image_live:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #     filters:
-      #       branches:
-      #         only: main
-      # - deploy_to_live_dev:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      #     filters:
-      #       branches:
-      #         only: main
-      # - deploy_to_live_production:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - acceptance_tests
-      #       - build_and_push_image_live
-      #     filters:
-      #       branches:
-      #         only: main
-      # - smoke_tests:
-      #     context: *moj-forms-context
-      #     requires:
-      #       - deploy_to_live_dev
-      #       - deploy_to_live_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only: main
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+          filters:
+            branches:
+              only: main
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+          filters:
+            branches:
+              only: main
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,7 @@ workflows:
             branches:
               only:
                 - main
+                - bugfix/content-with-validation-errors
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -282,31 +283,31 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only: main
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-          filters:
-            branches:
-              only: main
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-          filters:
-            branches:
-              only: main
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+      # - build_and_push_image_live:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #     filters:
+      #       branches:
+      #         only: main
+      # - deploy_to_live_dev:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      #     filters:
+      #       branches:
+      #         only: main
+      # - deploy_to_live_production:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - acceptance_tests
+      #       - build_and_push_image_live
+      #     filters:
+      #       branches:
+      #         only: main
+      # - smoke_tests:
+      #     context: *moj-forms-context
+      #     requires:
+      #       - deploy_to_live_dev
+      #       - deploy_to_live_production

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'address-json'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.19'
+gem 'metadata_presenter', '3.3.21'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.19)
+    metadata_presenter (3.3.21)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -650,7 +650,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.3.19)
+  metadata_presenter (= 3.3.21)
   prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (~> 7.0.5)


### PR DESCRIPTION
Resolves a bug where content wouldn't show on pages displaying validation errors

Working in deployed form
<img width="1100" alt="image" src="https://github.com/ministryofjustice/fb-runner/assets/7647632/65965168-078d-4f08-a75a-96baa48ae6b1">
