### PR TITLE
Update govuk frontend to 4.8.0 and bump presenter to 3.3.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'address-json'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.19'
+gem 'metadata_presenter', '3.3.21'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.19)
+    metadata_presenter (3.3.21)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -650,7 +650,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.3.19)
+  metadata_presenter (= 3.3.21)
   prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (~> 7.0.5)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@rails/ujs": "^7.0.4",
     "@rails/webpacker": "^5.4.3",
     "accessible-autocomplete": "^2.0.4",
-    "govuk-frontend": "4.3.1",
+    "govuk-frontend": "4.8.0",
     "promise-polyfill": "^8.3.0",
     "whatwg-fetch": "^3.6.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2782,9 +2782,10 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
 
-govuk-frontend@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz"
+govuk-frontend@4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
+  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.6:
   version "4.2.9"


### PR DESCRIPTION
Updates GOV.UK frontend to 4.8.0 to include the latest styles for the updated header with tudor crown.

Also updates Presenter to 3.3.21 which includes:
* Updated tudor crown svg in the header
* Fixes for disappearing content areas on validation errors