### PR TITLE
Bump metadata presenter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,7 @@ workflows:
             branches:
               only:
                 - main
+                - bump-metadata-gem
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -282,31 +283,31 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only: main
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-          filters:
-            branches:
-              only: main
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-          filters:
-            branches:
-              only: main
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+#      - build_and_push_image_live:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#          filters:
+#            branches:
+#              only: main
+#      - deploy_to_live_dev:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#          filters:
+#            branches:
+#              only: main
+#      - deploy_to_live_production:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#          filters:
+#            branches:
+#              only: main
+#      - smoke_tests:
+#          context: *moj-forms-context
+#          requires:
+#            - deploy_to_live_dev
+#            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,6 @@ workflows:
             branches:
               only:
                 - main
-                - bump-metadata-gem
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
@@ -283,31 +282,31 @@ workflows:
           requires:
             - deploy_to_test_dev
             - deploy_to_test_production
-#      - build_and_push_image_live:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#          filters:
-#            branches:
-#              only: main
-#      - deploy_to_live_dev:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#          filters:
-#            branches:
-#              only: main
-#      - deploy_to_live_production:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#          filters:
-#            branches:
-#              only: main
-#      - smoke_tests:
-#          context: *moj-forms-context
-#          requires:
-#            - deploy_to_live_dev
-#            - deploy_to_live_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only: main
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+          filters:
+            branches:
+              only: main
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+          filters:
+            branches:
+              only: main
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'bug-fixes'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'bugfix/conditional-check'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.22'
+gem 'metadata_presenter', '3.3.24'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-# gem 'metadata_presenter',
-#     github: 'ministryofjustice/fb-metadata-presenter',
-#     branch: 'bugfix/conditional-check'
+gem 'metadata_presenter',
+    github: 'ministryofjustice/fb-metadata-presenter',
+    branch: 'bug-fixes'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.22'
+# gem 'metadata_presenter', '3.3.22'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: a4a8918a091d8254d6ebcb76d5ffbf6b22fb558d
+  revision: 57e2b715b6192d87fc4adfc9571dcf585e9ba29f
   branch: bug-fixes
   specs:
     metadata_presenter (3.3.23)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 57e2b715b6192d87fc4adfc9571dcf585e9ba29f
-  branch: bug-fixes
-  specs:
-    metadata_presenter (3.3.23)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (~> 4.1.1)
-      json-schema (~> 4.1.1)
-      kramdown (~> 2.4.0)
-      rails (~> 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-      uk_postcode
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -238,6 +222,16 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    metadata_presenter (3.3.24)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (~> 4.1.1)
+      json-schema (~> 4.1.1)
+      kramdown (~> 2.4.0)
+      rails (~> 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+      uk_postcode
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -656,7 +650,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.3.24)
   prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (~> 7.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,19 @@
+GIT
+  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
+  revision: 6204fdf88a300e25fda1152d3b214e858d2992be
+  branch: bug-fixes
+  specs:
+    metadata_presenter (3.3.23)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (~> 4.1.1)
+      json-schema (~> 4.1.1)
+      kramdown (~> 2.4.0)
+      rails (~> 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+      uk_postcode
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -222,16 +238,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    metadata_presenter (3.3.22)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (~> 4.1.1)
-      json-schema (~> 4.1.1)
-      kramdown (~> 2.4.0)
-      rails (~> 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-      uk_postcode
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -650,7 +656,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.3.22)
+  metadata_presenter!
   prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (~> 7.0.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 6204fdf88a300e25fda1152d3b214e858d2992be
+  revision: a4a8918a091d8254d6ebcb76d5ffbf6b22fb558d
   branch: bug-fixes
   specs:
     metadata_presenter (3.3.23)
@@ -198,7 +198,7 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (37.5.1)
+    govuk_publishing_components (37.6.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
https://trello.com/c/bfXgPTNU
https://trello.com/c/sYULK6k1

This fixes 2 bugs, one with the positioning of the error summary component, and other related to uploaded jpeg files.

https://github.com/ministryofjustice/fb-metadata-presenter/pull/390