### PR TITLE
Backlink for missing page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,45 +269,44 @@ workflows:
             branches:
               only:
                 - main
-                - backlink-inexistant-page
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-#      - deploy_to_test_production:
-#          context: *moj-forms-context
-#          requires:
-#            - build_and_push_image_test
+      - deploy_to_test_production:
+          context: *moj-forms-context
+          requires:
+            - build_and_push_image_test
       - acceptance_tests:
           context: *moj-forms-context
           requires:
             - deploy_to_test_dev
-#            - deploy_to_test_production
-#      - build_and_push_image_live:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#          filters:
-#            branches:
-#              only: main
-#      - deploy_to_live_dev:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#          filters:
-#            branches:
-#              only: main
-#      - deploy_to_live_production:
-#          context: *moj-forms-context
-#          requires:
-#            - acceptance_tests
-#            - build_and_push_image_live
-#          filters:
-#            branches:
-#              only: main
-#      - smoke_tests:
-#          context: *moj-forms-context
-#          requires:
-#            - deploy_to_live_dev
-#            - deploy_to_live_production
+            - deploy_to_test_production
+      - build_and_push_image_live:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+          filters:
+            branches:
+              only: main
+      - deploy_to_live_dev:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+          filters:
+            branches:
+              only: main
+      - deploy_to_live_production:
+          context: *moj-forms-context
+          requires:
+            - acceptance_tests
+            - build_and_push_image_live
+          filters:
+            branches:
+              only: main
+      - smoke_tests:
+          context: *moj-forms-context
+          requires:
+            - deploy_to_live_dev
+            - deploy_to_live_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,44 +269,45 @@ workflows:
             branches:
               only:
                 - main
+                - backlink-inexistant-page
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:
             - build_and_push_image_test
-      - deploy_to_test_production:
-          context: *moj-forms-context
-          requires:
-            - build_and_push_image_test
+#      - deploy_to_test_production:
+#          context: *moj-forms-context
+#          requires:
+#            - build_and_push_image_test
       - acceptance_tests:
           context: *moj-forms-context
           requires:
             - deploy_to_test_dev
-            - deploy_to_test_production
-      - build_and_push_image_live:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-          filters:
-            branches:
-              only: main
-      - deploy_to_live_dev:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-          filters:
-            branches:
-              only: main
-      - deploy_to_live_production:
-          context: *moj-forms-context
-          requires:
-            - acceptance_tests
-            - build_and_push_image_live
-          filters:
-            branches:
-              only: main
-      - smoke_tests:
-          context: *moj-forms-context
-          requires:
-            - deploy_to_live_dev
-            - deploy_to_live_production
+#            - deploy_to_test_production
+#      - build_and_push_image_live:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#          filters:
+#            branches:
+#              only: main
+#      - deploy_to_live_dev:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#          filters:
+#            branches:
+#              only: main
+#      - deploy_to_live_production:
+#          context: *moj-forms-context
+#          requires:
+#            - acceptance_tests
+#            - build_and_push_image_live
+#          filters:
+#            branches:
+#              only: main
+#      - smoke_tests:
+#          context: *moj-forms-context
+#          requires:
+#            - deploy_to_live_dev
+#            - deploy_to_live_production

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ ruby '3.1.3'
 #     github: 'ministryofjustice/fb-metadata-presenter',
 #     branch: 'autocomplete-special-character-support'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-gem 'metadata_presenter', '3.3.28'
+gem 'metadata_presenter', '3.3.29'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    metadata_presenter (3.3.28)
+    metadata_presenter (3.3.29)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (~> 4.1.1)
       json-schema (~> 4.1.1)
@@ -438,7 +438,7 @@ GEM
       opentelemetry-semantic_conventions (>= 1.8.0)
     opentelemetry-registry (0.3.1)
       opentelemetry-api (~> 1.1)
-    opentelemetry-sdk (1.4.0)
+    opentelemetry-sdk (1.4.1)
       opentelemetry-api (~> 1.1)
       opentelemetry-common (~> 0.20)
       opentelemetry-registry (~> 0.2)
@@ -651,7 +651,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter (= 3.3.28)
+  metadata_presenter (= 3.3.29)
   prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (~> 7.0.5)

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Navigation' do
   before do
     allow(VerifySession).to receive(:before).and_return(false)
     allow(Rails.configuration).to receive(:autocomplete_items).and_return(autocomplete_items)
+    allow(@page).to receive(:url).and_return('some_previous_url')
   end
 
   scenario 'when I navigate forward and back through the form' do


### PR DESCRIPTION
[Trello](https://trello.com/c/fxjAcvOd/3995-back-link-on-page-missing-page-is-incorrect-prioritisation-score-9)

Backling for missing page currently refer to the previous page of the previous page. We have updated the presenter to fix. This PR bump the version of the presenter and update the tests.

AT passed OK: [circle](https://app.circleci.com/pipelines/github/ministryofjustice/fb-runner/7204/workflows/53ac0b66-a765-4c5d-b2b1-a3f34cc62ac5/jobs/24399)
