### PR TITLE
Bump metadata presenter to v3.3.34

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,6 @@ workflows:
             branches:
               only:
                 - main
-                - bump-metadata-gem
       - deploy_to_test_dev:
           context: *moj-forms-context
           requires:

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,11 @@ ruby '3.1.3'
 
 # Metadata presenter - if you need to be on development you can uncomment
 # one of these lines:
-gem 'metadata_presenter',
-    github: 'ministryofjustice/fb-metadata-presenter',
-    branch: 'cy-locales'
+# gem 'metadata_presenter',
+#     github: 'ministryofjustice/fb-metadata-presenter',
+#     branch: 'back-link-nil-guard'
 # gem 'metadata_presenter', path: '../fb-metadata-presenter'
-# gem 'metadata_presenter', '3.3.32'
+gem 'metadata_presenter', '3.3.34'
 
 gem 'aws-sdk-s3'
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,3 @@
-GIT
-  remote: https://github.com/ministryofjustice/fb-metadata-presenter.git
-  revision: 5d6e62345ab1080170197d7ee3ae94e166b485c5
-  branch: cy-locales
-  specs:
-    metadata_presenter (3.3.34)
-      govspeak (~> 7.1)
-      govuk_design_system_formbuilder (~> 4.1.1)
-      json-schema (~> 4.1.1)
-      kramdown (~> 2.4.0)
-      rails (~> 7.0.0)
-      sassc-rails (= 2.1.2)
-      sprockets
-      sprockets-rails
-      uk_postcode
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -238,6 +222,16 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    metadata_presenter (3.3.34)
+      govspeak (~> 7.1)
+      govuk_design_system_formbuilder (~> 4.1.1)
+      json-schema (~> 4.1.1)
+      kramdown (~> 2.4.0)
+      rails (~> 7.0.0)
+      sassc-rails (= 2.1.2)
+      sprockets
+      sprockets-rails
+      uk_postcode
     method_source (1.0.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.5)
@@ -656,7 +650,7 @@ DEPENDENCIES
   fb-jwt-auth (= 0.10.0)
   jwt
   listen (~> 3.8)
-  metadata_presenter!
+  metadata_presenter (= 3.3.34)
   prometheus-client (~> 4.2.0)
   puma (~> 6.4)
   rails (~> 7.0.5)


### PR DESCRIPTION
Version 3.3.34 of the gem adds welsh locales for the authorisation page, and the regex validation error message.