### PR TITLE
Bugfix: Pin Chrome in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,6 +149,7 @@ jobs:
       - checkout
       - run: sudo apt-get update
       - browser-tools/install-chrome:
+          # pin to version 132 due to race condition in latest release: https://github.com/teamcapybara/capybara/issues/2800
           chrome-version: "132.0.6834.83"
       - browser-tools/install-chromedriver
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,8 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "132.0.6834.83"
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install


### PR DESCRIPTION
Pin the Chrome version used for browser testing in the runner. 

This is due to this issue: https://github.com/teamcapybara/capybara/issues/2800

Not a perm fix but a fix for now to unblock runner pipeline.

We have also found a gem https://github.com/makandra/capybara-lockstep which looks promising and seems to be helping stabilise our other repos. May look to implement this across formbuilder.