### PR TITLE
Allow more dependabot updates for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,5 @@ updates:
     interval: daily
   # Disable version updates, but leave security updates
   open-pull-requests-limit: 0
+  allow:
+    - dependency-type: "all"


### PR DESCRIPTION
This config might allow dependabot to update the subdependencies of packages, which might help us resolve high severity security issues