### PR TITLE
CDPTKAN-1053: Remove brakeman ruby EOL warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - checkout
       - ruby/install-deps
-      - run: bundle exec brakeman -q --no-pager --except EOLRuby
+      - run: bundle exec brakeman -q --no-pager
       - slack/status: *slack_status
   test:
     docker: *ruby_image


### PR DESCRIPTION
`bundle exec brakeman -q --no-pager`

<img width="989" height="490" alt="Screenshot 2026-05-20 at 13 24 40" src="https://github.com/user-attachments/assets/3af14d97-ade5-4d42-b445-862808bbacfd" />
