### PR TITLE
CDPTKAN-780: MOJ forms host header poisoning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,6 @@ module FbRunner
     # Don't generate system test files.
     config.generators.system_tests = nil
     config.action_dispatch.ip_spoofing_check = false
+    config.action_controller.forgery_protection_origin_check = true
   end
 end


### PR DESCRIPTION
[CWE-346: Origin Validation Error (4.20)](https://cwe.mitre.org/data/definitions/346.html)

JIRA: https://dsdmoj.atlassian.net/browse/CDPTKAN-780